### PR TITLE
massive warning and typo fixes

### DIFF
--- a/YNPageViewController/YNPageViewController.xcodeproj/project.pbxproj
+++ b/YNPageViewController/YNPageViewController.xcodeproj/project.pbxproj
@@ -89,7 +89,7 @@
 		2E89D018208C569700D038D6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2E89D016208C569700D038D6 /* LaunchScreen.storyboard */; };
 		2E89D01B208C569700D038D6 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E89D01A208C569700D038D6 /* main.m */; };
 		2E89D02E208C5A1100D038D6 /* YNPageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E89D02D208C5A1100D038D6 /* YNPageViewController.m */; };
-		2E89D031208C5AFE00D038D6 /* YNPageConfigration.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E89D030208C5AFE00D038D6 /* YNPageConfigration.m */; };
+		2E89D031208C5AFE00D038D6 /* YNPageConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E89D030208C5AFE00D038D6 /* YNPageConfiguration.m */; };
 		2EFDC1D520E0E9B10018455F /* YNScrollMenuStyleVC.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EFDC1D420E0E9B10018455F /* YNScrollMenuStyleVC.m */; };
 		2EFDC1D920E213440018455F /* YNLoadPageVC.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EFDC1D820E213440018455F /* YNLoadPageVC.m */; };
 		2EFDC1DC20E2156E0018455F /* BaseViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EFDC1DB20E2156E0018455F /* BaseViewController.m */; };
@@ -261,8 +261,8 @@
 		2E89D01A208C569700D038D6 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		2E89D02C208C5A1100D038D6 /* YNPageViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = YNPageViewController.h; sourceTree = "<group>"; };
 		2E89D02D208C5A1100D038D6 /* YNPageViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = YNPageViewController.m; sourceTree = "<group>"; };
-		2E89D02F208C5AFE00D038D6 /* YNPageConfigration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = YNPageConfigration.h; sourceTree = "<group>"; };
-		2E89D030208C5AFE00D038D6 /* YNPageConfigration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = YNPageConfigration.m; sourceTree = "<group>"; };
+		2E89D02F208C5AFE00D038D6 /* YNPageConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = YNPageConfiguration.h; sourceTree = "<group>"; };
+		2E89D030208C5AFE00D038D6 /* YNPageConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = YNPageConfiguration.m; sourceTree = "<group>"; };
 		2EFDC1D320E0E9B10018455F /* YNScrollMenuStyleVC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = YNScrollMenuStyleVC.h; sourceTree = "<group>"; };
 		2EFDC1D420E0E9B10018455F /* YNScrollMenuStyleVC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = YNScrollMenuStyleVC.m; sourceTree = "<group>"; };
 		2EFDC1D720E213440018455F /* YNLoadPageVC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = YNLoadPageVC.h; sourceTree = "<group>"; };
@@ -702,8 +702,8 @@
 				2E3F8DCE20F9FA6A009FDA84 /* View */,
 				2E89D02C208C5A1100D038D6 /* YNPageViewController.h */,
 				2E89D02D208C5A1100D038D6 /* YNPageViewController.m */,
-				2E89D02F208C5AFE00D038D6 /* YNPageConfigration.h */,
-				2E89D030208C5AFE00D038D6 /* YNPageConfigration.m */,
+				2E89D02F208C5AFE00D038D6 /* YNPageConfiguration.h */,
+				2E89D030208C5AFE00D038D6 /* YNPageConfiguration.m */,
 			);
 			path = YNPageViewController;
 			sourceTree = "<group>";
@@ -752,7 +752,7 @@
 		2E89D000208C569700D038D6 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0920;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = yongneng;
 				TargetAttributes = {
 					2E89D007208C569700D038D6 = {
@@ -808,7 +808,7 @@
 				2E5F7E8520DCA5860069962B /* SDCycleScrollView.m in Sources */,
 				2E7FFF6021F16E2A00F29750 /* UITouch+MemoryLeak.m in Sources */,
 				2E5F7E8720DCA5860069962B /* NSData+ImageContentType.m in Sources */,
-				2E89D031208C5AFE00D038D6 /* YNPageConfigration.m in Sources */,
+				2E89D031208C5AFE00D038D6 /* YNPageConfiguration.m in Sources */,
 				2E5F7EA020DCAC840069962B /* YNSuspendCenterPageVC.m in Sources */,
 				2E5F7E7220DCA5860069962B /* MJRefreshAutoNormalFooter.m in Sources */,
 				2E5F7E6F20DCA5860069962B /* MJRefreshFooter.m in Sources */,
@@ -919,6 +919,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -926,8 +927,10 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -974,6 +977,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -981,8 +985,10 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;

--- a/YNPageViewController/YNPageViewController/Libs/ThirdParty/FTPopOverMenu/FTPopOverMenu.h
+++ b/YNPageViewController/YNPageViewController/Libs/ThirdParty/FTPopOverMenu/FTPopOverMenu.h
@@ -11,13 +11,13 @@
 /**
  *  FTPopOverMenuDoneBlock
  *
- *  @param index SlectedIndex
+ *  @param selectedIndex SlectedIndex
  */
 typedef void (^FTPopOverMenuDoneBlock)(NSInteger selectedIndex);
 /**
  *  FTPopOverMenuDismissBlock
  */
-typedef void (^FTPopOverMenuDismissBlock)();
+typedef void (^FTPopOverMenuDismissBlock)(void);
 
 /**
  *  -----------------------FTPopOverMenuConfiguration-----------------------

--- a/YNPageViewController/YNPageViewController/Libs/ThirdParty/FTPopOverMenu/FTPopOverMenu.m
+++ b/YNPageViewController/YNPageViewController/Libs/ThirdParty/FTPopOverMenu/FTPopOverMenu.m
@@ -150,7 +150,7 @@ typedef NS_ENUM(NSUInteger, FTPopOverMenuArrowDirection) {
                             if (configuration.ignoreImageOriginalColor) {
                                 image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
                             }
-                            _iconImageView.image = image;
+            self->_iconImageView.image = image;
                         }];
         [self.contentView addSubview:self.iconImageView];
     }
@@ -166,7 +166,7 @@ typedef NS_ENUM(NSUInteger, FTPopOverMenuArrowDirection) {
  get image from local or remote
  
  @param resource image reource
- @param doneBlock get image back
+ @param completion get image back
  */
 -(void)getImageWithResource:(id)resource completion:(void (^)(UIImage *image))completion
 {
@@ -181,7 +181,7 @@ typedef NS_ENUM(NSUInteger, FTPopOverMenuArrowDirection) {
     }else if ([resource isKindOfClass:[NSURL class]]) {
         [self downloadImageWithURL:resource completion:completion];
     }else{
-        NSLog(@"Image resource not recougnized.");
+        NSLog(@"Image resource not recognized.");
         completion(nil);
     }
 }
@@ -190,7 +190,7 @@ typedef NS_ENUM(NSUInteger, FTPopOverMenuArrowDirection) {
  download image if needed, cache image into disk if needed.
  
  @param url imageURL
- @param doneBlock get image back
+ @param completion get image back
  */
 -(void)downloadImageWithURL:(NSURL *)url completion:(void (^)(UIImage *image))completion
 {
@@ -224,7 +224,7 @@ typedef NS_ENUM(NSUInteger, FTPopOverMenuArrowDirection) {
 }
 
 /**
- get local disk cash filePath for imageurl
+ get local disk cash filePath for image url
  
  @param url imageURL
  @return filePath
@@ -765,8 +765,8 @@ typedef NS_ENUM(NSUInteger, FTPopOverMenuArrowDirection) {
     self.isCurrentlyOnScreen = YES;
     [UIView animateWithDuration:FTDefaultAnimationDuration
                      animations:^{
-                         _popMenuView.alpha = 1;
-                         _popMenuView.transform = CGAffineTransformMakeScale(1, 1);
+                        self->_popMenuView.alpha = 1;
+                        self->_popMenuView.transform = CGAffineTransformMakeScale(1, 1);
                      }];
 }
 
@@ -784,8 +784,8 @@ typedef NS_ENUM(NSUInteger, FTPopOverMenuArrowDirection) {
 {
     [UIView animateWithDuration:FTDefaultAnimationDuration
                      animations:^{
-                         _popMenuView.alpha = 0;
-                         _popMenuView.transform = CGAffineTransformMakeScale(0.1, 0.1);
+                        self->_popMenuView.alpha = 0;
+                        self->_popMenuView.transform = CGAffineTransformMakeScale(0.1, 0.1);
                      }completion:^(BOOL finished) {
                          if (finished) {
                              [self.popMenuView removeFromSuperview];

--- a/YNPageViewController/YNPageViewController/Libs/ThirdParty/MJRefresh/Base/MJRefreshComponent.h
+++ b/YNPageViewController/YNPageViewController/Libs/ThirdParty/MJRefresh/Base/MJRefreshComponent.h
@@ -29,11 +29,11 @@ typedef NS_ENUM(NSInteger, MJRefreshState) {
 };
 
 /** 进入刷新状态的回调 */
-typedef void (^MJRefreshComponentRefreshingBlock)();
+typedef void (^MJRefreshComponentRefreshingBlock)(void);
 /** 开始刷新后的回调(进入刷新状态后的回调) */
-typedef void (^MJRefreshComponentbeginRefreshingCompletionBlock)();
+typedef void (^MJRefreshComponentbeginRefreshingCompletionBlock)(void);
 /** 结束刷新后的回调 */
-typedef void (^MJRefreshComponentEndRefreshingCompletionBlock)();
+typedef void (^MJRefreshComponentEndRefreshingCompletionBlock)(void);
 
 /** 刷新控件的基类 */
 @interface MJRefreshComponent : UIView
@@ -59,14 +59,14 @@ typedef void (^MJRefreshComponentEndRefreshingCompletionBlock)();
 #pragma mark - 刷新状态控制
 /** 进入刷新状态 */
 - (void)beginRefreshing;
-- (void)beginRefreshingWithCompletionBlock:(void (^)())completionBlock;
+- (void)beginRefreshingWithCompletionBlock:(void (^)(void))completionBlock;
 /** 开始刷新后的回调(进入刷新状态后的回调) */
 @property (copy, nonatomic) MJRefreshComponentbeginRefreshingCompletionBlock beginRefreshingCompletionBlock;
 /** 结束刷新的回调 */
 @property (copy, nonatomic) MJRefreshComponentEndRefreshingCompletionBlock endRefreshingCompletionBlock;
 /** 结束刷新状态 */
 - (void)endRefreshing;
-- (void)endRefreshingWithCompletionBlock:(void (^)())completionBlock;
+- (void)endRefreshingWithCompletionBlock:(void (^)(void))completionBlock;
 /** 是否正在刷新 */
 - (BOOL)isRefreshing;
 /** 刷新状态 一般交给子类内部实现 */

--- a/YNPageViewController/YNPageViewController/Libs/ThirdParty/MJRefresh/Base/MJRefreshComponent.m
+++ b/YNPageViewController/YNPageViewController/Libs/ThirdParty/MJRefresh/Base/MJRefreshComponent.m
@@ -161,7 +161,7 @@
     }
 }
 
-- (void)beginRefreshingWithCompletionBlock:(void (^)())completionBlock
+- (void)beginRefreshingWithCompletionBlock:(void (^)(void))completionBlock
 {
     self.beginRefreshingCompletionBlock = completionBlock;
     
@@ -174,7 +174,7 @@
     self.state = MJRefreshStateIdle;
 }
 
-- (void)endRefreshingWithCompletionBlock:(void (^)())completionBlock
+- (void)endRefreshingWithCompletionBlock:(void (^)(void))completionBlock
 {
     self.endRefreshingCompletionBlock = completionBlock;
     

--- a/YNPageViewController/YNPageViewController/Libs/ThirdParty/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
+++ b/YNPageViewController/YNPageViewController/Libs/ThirdParty/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
@@ -69,6 +69,7 @@ NSString * const ID = @"cycleCell";
 
 - (void)awakeFromNib
 {
+    [super awakeFromNib];
     [self initialization];
     [self setupMainView];
 }

--- a/YNPageViewController/YNPageViewController/Libs/ThirdParty/SDWebImage/SDImageCache.m
+++ b/YNPageViewController/YNPageViewController/Libs/ThirdParty/SDWebImage/SDImageCache.m
@@ -295,12 +295,12 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 
 - (void)diskImageExistsWithKey:(NSString *)key completion:(SDWebImageCheckCacheCompletionBlock)completionBlock {
     dispatch_async(_ioQueue, ^{
-        BOOL exists = [_fileManager fileExistsAtPath:[self defaultCachePathForKey:key]];
+        BOOL exists = [self->_fileManager fileExistsAtPath:[self defaultCachePathForKey:key]];
 
         // fallback because of https://github.com/rs/SDWebImage/pull/976 that added the extension to the disk file name
         // checking the key with and without the extension
         if (!exists) {
-            exists = [_fileManager fileExistsAtPath:[[self defaultCachePathForKey:key] stringByDeletingPathExtension]];
+            exists = [self->_fileManager fileExistsAtPath:[[self defaultCachePathForKey:key] stringByDeletingPathExtension]];
         }
 
         if (completionBlock) {

--- a/YNPageViewController/YNPageViewController/Libs/ThirdParty/SDWebImage/SDWebImageCompat.h
+++ b/YNPageViewController/YNPageViewController/Libs/ThirdParty/SDWebImage/SDWebImageCompat.h
@@ -53,7 +53,7 @@
 
 extern UIImage *SDScaledImageForKey(NSString *key, UIImage *image);
 
-typedef void(^SDWebImageNoParamsBlock)();
+typedef void(^SDWebImageNoParamsBlock)(void);
 
 extern NSString *const SDWebImageErrorDomain;
 

--- a/YNPageViewController/YNPageViewController/Libs/YNPageViewController/Category/UIScrollView+YNPageExtend.h
+++ b/YNPageViewController/YNPageViewController/Libs/YNPageViewController/Category/UIScrollView+YNPageExtend.h
@@ -10,7 +10,7 @@
 
 typedef void(^YNPageScrollViewDidScrollView)(UIScrollView *scrollView);
 
-typedef void(^YNPageScrollViewBeginDragginScrollView)(UIScrollView *scrollView);
+typedef void(^YNPageScrollViewBeginDraggingScrollView)(UIScrollView *scrollView);
 
 @interface UIScrollView (YNPageExtend)
 
@@ -18,7 +18,7 @@ typedef void(^YNPageScrollViewBeginDragginScrollView)(UIScrollView *scrollView);
 
 @property (nonatomic, copy) YNPageScrollViewDidScrollView yn_pageScrollViewDidScrollView;
 
-@property (nonatomic, copy) YNPageScrollViewBeginDragginScrollView yn_pageScrollViewBeginDragginScrollView;
+@property (nonatomic, copy) YNPageScrollViewBeginDraggingScrollView yn_pageScrollViewBeginDraggingScrollView;
 
 - (void)yn_setContentOffsetY:(CGFloat)offsetY;
 

--- a/YNPageViewController/YNPageViewController/Libs/YNPageViewController/Category/UIScrollView+YNPageExtend.m
+++ b/YNPageViewController/YNPageViewController/Libs/YNPageViewController/Category/UIScrollView+YNPageExtend.m
@@ -28,8 +28,8 @@
 
 - (void)yn_scrollViewWillBeginDragging {
     [self yn_scrollViewWillBeginDragging];
-    if (self.yn_observerDidScrollView && self.yn_pageScrollViewBeginDragginScrollView) {
-        self.yn_pageScrollViewBeginDragginScrollView(self);
+    if (self.yn_observerDidScrollView && self.yn_pageScrollViewBeginDraggingScrollView) {
+        self.yn_pageScrollViewBeginDraggingScrollView(self);
     }
 }
 
@@ -51,12 +51,12 @@
     objc_setAssociatedObject(self, @selector(yn_pageScrollViewDidScrollView), yn_pageScrollViewDidScrollView, OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
 
-- (YNPageScrollViewBeginDragginScrollView)yn_pageScrollViewBeginDragginScrollView {
+- (YNPageScrollViewBeginDraggingScrollView)yn_pageScrollViewBeginDraggingScrollView {
     return objc_getAssociatedObject(self, _cmd);
 }
 
-- (void)setYn_pageScrollViewBeginDragginScrollView:(YNPageScrollViewBeginDragginScrollView)yn_pageScrollViewBeginDragginScrollView {
-    objc_setAssociatedObject(self, @selector(yn_pageScrollViewBeginDragginScrollView), yn_pageScrollViewBeginDragginScrollView, OBJC_ASSOCIATION_COPY_NONATOMIC);
+- (void)setYn_pageScrollViewBeginDraggingScrollView:(YNPageScrollViewBeginDraggingScrollView)yn_pageScrollViewBeginDraggingScrollView {
+    objc_setAssociatedObject(self, @selector(yn_pageScrollViewBeginDraggingScrollView), yn_pageScrollViewBeginDraggingScrollView, OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
 
 #pragma amrk - Swizzle

--- a/YNPageViewController/YNPageViewController/Libs/YNPageViewController/Category/UIViewController+YNPageExtend.h
+++ b/YNPageViewController/YNPageViewController/Libs/YNPageViewController/Category/UIViewController+YNPageExtend.h
@@ -13,7 +13,7 @@
 
 - (YNPageViewController *)yn_pageViewController;
 
-- (YNPageConfigration *)config;
+- (YNPageConfiguration *)config;
 
 - (YNPageScrollView *)bgScrollView;
 

--- a/YNPageViewController/YNPageViewController/Libs/YNPageViewController/Category/UIViewController+YNPageExtend.m
+++ b/YNPageViewController/YNPageViewController/Libs/YNPageViewController/Category/UIViewController+YNPageExtend.m
@@ -14,7 +14,7 @@
     return (YNPageViewController *)self.parentViewController;
 }
 
-- (YNPageConfigration *)config {
+- (YNPageConfiguration *)config {
     return self.yn_pageViewController.config;
 }
 

--- a/YNPageViewController/YNPageViewController/Libs/YNPageViewController/View/YNPageScrollMenuView.h
+++ b/YNPageViewController/YNPageViewController/Libs/YNPageViewController/View/YNPageScrollMenuView.h
@@ -8,15 +8,15 @@
 
 #import <UIKit/UIKit.h>
 
-@class YNPageConfigration;
+@class YNPageConfiguration;
 
 @protocol YNPageScrollMenuViewDelegate <NSObject>
 @optional
 /// 点击item
-- (void)pagescrollMenuViewItemOnClick:(UIButton *)button index:(NSInteger)index;
+- (void)pageScrollMenuViewItemOnClick:(UIButton *)button index:(NSInteger)index;
 
 /// 点击Add按钮
-- (void)pagescrollMenuViewAddButtonAction:(UIButton *)button;
+- (void)pageScrollMenuViewAddButtonAction:(UIButton *)button;
 
 @end
 
@@ -36,13 +36,13 @@
 
  @param frame 大小
  @param titles 标题
- @param configration 配置信息
+ @param configuration 配置信息
  @param delegate 代理
  @param currentIndex 当前选中下标
  */
-+ (instancetype)pagescrollMenuViewWithFrame:(CGRect)frame
++ (instancetype)pageScrollMenuViewWithFrame:(CGRect)frame
                                      titles:(NSMutableArray *)titles
-                               configration:(YNPageConfigration *)configration
+                               configuration:(YNPageConfiguration *)configuration
                                    delegate:(id<YNPageScrollMenuViewDelegate>)delegate
                                currentIndex:(NSInteger)currentIndex;
 

--- a/YNPageViewController/YNPageViewController/Libs/YNPageViewController/View/YNPageScrollMenuView.m
+++ b/YNPageViewController/YNPageViewController/Libs/YNPageViewController/View/YNPageScrollMenuView.m
@@ -7,26 +7,26 @@
 //
 
 #import "YNPageScrollMenuView.h"
-#import "YNPageConfigration.h"
+#import "YNPageConfiguration.h"
 #import "YNPageScrollView.h"
 #import "UIView+YNPageExtend.h"
 
-#define kYNPageScrollMenuViewConverMarginX 5
+#define kYNPageScrollMenuViewCoverMarginX 5
 
-#define kYNPageScrollMenuViewConverMarginW 10
+#define kYNPageScrollMenuViewCoverMarginW 10
 
 @interface YNPageScrollMenuView ()
 
 /// line指示器
 @property (nonatomic, strong) UIView *lineView;
 /// 蒙层
-@property (nonatomic, strong) UIView *converView;
+@property (nonatomic, strong) UIView *coverView;
 /// ScrollView
 @property (nonatomic, strong) YNPageScrollView *scrollView;
 /// 底部线条
 @property (nonatomic, strong) UIView *bottomLine;
 /// 配置信息
-@property (nonatomic, strong) YNPageConfigration *configration;
+@property (nonatomic, strong) YNPageConfiguration *configuration;
 /// 代理
 @property (nonatomic, weak) id<YNPageScrollMenuViewDelegate> delegate;
 /// 上次index
@@ -44,18 +44,18 @@
 
 #pragma mark - Init Method
 
-+ (instancetype)pagescrollMenuViewWithFrame:(CGRect)frame
++ (instancetype)pageScrollMenuViewWithFrame:(CGRect)frame
                                      titles:(NSMutableArray *)titles
-                               configration:(YNPageConfigration *)configration
+                               configuration:(YNPageConfiguration *)configuration
                                    delegate:(id<YNPageScrollMenuViewDelegate>)delegate
                                currentIndex:(NSInteger)currentIndex {
-    frame.size.height = configration.menuHeight;
-    frame.size.width = configration.menuWidth;
+    frame.size.height = configuration.menuHeight;
+    frame.size.width = configuration.menuWidth;
     
     YNPageScrollMenuView *menuView = [[YNPageScrollMenuView alloc] initWithFrame:frame];
     menuView.titles = titles;
     menuView.delegate = delegate;
-    menuView.configration = configration ?: [YNPageConfigration defaultConfig];
+    menuView.configuration = configuration ?: [YNPageConfiguration defaultConfig];
     menuView.currentIndex = currentIndex;
     menuView.itemsArrayM = @[].mutableCopy;
     menuView.itemsWidthArraM = @[].mutableCopy;
@@ -66,14 +66,14 @@
 
 #pragma mark - Private Method
 - (void)setupSubViews {
-    self.backgroundColor = self.configration.scrollViewBackgroundColor;
+    self.backgroundColor = self.configuration.scrollViewBackgroundColor;
     [self setupItems];
     [self setupOtherViews];
 }
 
 - (void)setupItems {
-    if (self.configration.buttonArray.count > 0 && self.titles.count == self.configration.buttonArray.count) {
-        [self.configration.buttonArray enumerateObjectsUsingBlock:^(UIButton * _Nonnull itemButton, NSUInteger idx, BOOL * _Nonnull stop) {
+    if (self.configuration.buttonArray.count > 0 && self.titles.count == self.configuration.buttonArray.count) {
+        [self.configuration.buttonArray enumerateObjectsUsingBlock:^(UIButton * _Nonnull itemButton, NSUInteger idx, BOOL * _Nonnull stop) {
             [self setupButton:itemButton title:self.titles[idx] idx:idx];
         }];
     } else {
@@ -85,8 +85,8 @@
 }
 
 - (void)setupButton:(UIButton *)itemButton title:(NSString *)title idx:(NSInteger)idx {
-    itemButton.titleLabel.font = self.configration.selectedItemFont;
-    [itemButton setTitleColor:self.configration.normalItemColor forState:UIControlStateNormal];
+    itemButton.titleLabel.font = self.configuration.selectedItemFont;
+    [itemButton setTitleColor:self.configuration.normalItemColor forState:UIControlStateNormal];
     [itemButton setTitle:title forState:UIControlStateNormal];
     itemButton.tag = idx;
     [itemButton addTarget:self action:@selector(itemButtonOnClick:) forControlEvents:UIControlEventTouchUpInside];
@@ -97,9 +97,9 @@
 }
 
 - (void)setupOtherViews {
-    self.scrollView.frame = CGRectMake(0, 0, self.configration.showAddButton ? self.yn_width - self.yn_height : self.yn_width, self.yn_height);
+    self.scrollView.frame = CGRectMake(0, 0, self.configuration.showAddButton ? self.yn_width - self.yn_height : self.yn_width, self.yn_height);
     [self addSubview:self.scrollView];
-    if (self.configration.showAddButton) {
+    if (self.configuration.showAddButton) {
         self.addButton.frame = CGRectMake(self.yn_width - self.yn_height, 0, self.yn_height, self.yn_height);
         [self addSubview:self.addButton];
     }
@@ -108,19 +108,19 @@
     __block CGFloat itemX = 0;
     __block CGFloat itemY = 0;
     __block CGFloat itemW = 0;
-    __block CGFloat itemH = self.yn_height - self.configration.lineHeight;
+    __block CGFloat itemH = self.yn_height - self.configuration.lineHeight;
     
     [self.itemsArrayM enumerateObjectsUsingBlock:^(UIButton * _Nonnull button, NSUInteger idx, BOOL * _Nonnull stop) {
         if (idx == 0) {
-            itemX += self.configration.itemLeftAndRightMargin;
+            itemX += self.configuration.itemLeftAndRightMargin;
         }else{
-            itemX += self.configration.itemMargin + [self.itemsWidthArraM[idx - 1] floatValue];
+            itemX += self.configuration.itemMargin + [self.itemsWidthArraM[idx - 1] floatValue];
         }
         button.frame = CGRectMake(itemX, itemY, [self.itemsWidthArraM[idx] floatValue], itemH);
     }];
     
-    CGFloat scrollSizeWidht = self.configration.itemLeftAndRightMargin + CGRectGetMaxX([[self.itemsArrayM lastObject] frame]);
-    if (scrollSizeWidht < self.scrollView.yn_width) {//不超出宽度
+    CGFloat scrollSizeWidth = self.configuration.itemLeftAndRightMargin + CGRectGetMaxX([[self.itemsArrayM lastObject] frame]);
+    if (scrollSizeWidth < self.scrollView.yn_width) {//不超出宽度
         itemX = 0;
         itemY = 0;
         itemW = 0;
@@ -129,15 +129,15 @@
             left += [width floatValue];
         }
         
-        left = (self.scrollView.yn_width - left - self.configration.itemMargin * (self.itemsWidthArraM.count-1)) * 0.5;
+        left = (self.scrollView.yn_width - left - self.configuration.itemMargin * (self.itemsWidthArraM.count-1)) * 0.5;
         /// 居中且有剩余间距
-        if (self.configration.aligmentModeCenter && left >= 0) {
+        if (self.configuration.alignmentModeCenter && left >= 0) {
             [self.itemsArrayM enumerateObjectsUsingBlock:^(UIButton  * button, NSUInteger idx, BOOL * _Nonnull stop) {
                 
                 if (idx == 0) {
                     itemX += left;
                 }else{
-                    itemX += self.configration.itemMargin + [self.itemsWidthArraM[idx - 1] floatValue];
+                    itemX += self.configuration.itemMargin + [self.itemsWidthArraM[idx - 1] floatValue];
                 }
                 button.frame = CGRectMake(itemX, itemY, [self.itemsWidthArraM[idx] floatValue], itemH);
             }];
@@ -146,7 +146,7 @@
             
         } else {
             /// 不能滚动则平分
-            if (!self.configration.scrollMenu) {
+            if (!self.configuration.scrollMenu) {
                 [self.itemsArrayM enumerateObjectsUsingBlock:^(UIButton  * button, NSUInteger idx, BOOL * _Nonnull stop) {
                     itemW = self.scrollView.yn_width / self.itemsArrayM.count;
                     itemX = itemW *idx;
@@ -156,50 +156,50 @@
                 self.scrollView.contentSize = CGSizeMake(CGRectGetMaxX([[self.itemsArrayM lastObject] frame]), self.scrollView.yn_height);
                 
             } else {
-                self.scrollView.contentSize = CGSizeMake(scrollSizeWidht, self.scrollView.yn_height);
+                self.scrollView.contentSize = CGSizeMake(scrollSizeWidth, self.scrollView.yn_height);
             }
         }
     } else { /// 大于scrollView的width·
-        self.scrollView.contentSize = CGSizeMake(scrollSizeWidht, self.scrollView.yn_height);
+        self.scrollView.contentSize = CGSizeMake(scrollSizeWidth, self.scrollView.yn_height);
     }
     
     CGFloat lineX = [(UIButton *)[self.itemsArrayM firstObject] yn_x];
-    CGFloat lineY = self.scrollView.yn_height - self.configration.lineHeight;
+    CGFloat lineY = self.scrollView.yn_height - self.configuration.lineHeight;
     CGFloat lineW = [[self.itemsArrayM firstObject] yn_width];
-    CGFloat lineH = self.configration.lineHeight;
+    CGFloat lineH = self.configuration.lineHeight;
     
     /// 处理Line宽度等于字体宽度
-    if (!self.configration.scrollMenu &&
-        !self.configration.aligmentModeCenter &&
-        self.configration.lineWidthEqualFontWidth) {
+    if (!self.configuration.scrollMenu &&
+        !self.configuration.alignmentModeCenter &&
+        self.configuration.lineWidthEqualFontWidth) {
         lineX = [(UIButton *)[self.itemsArrayM firstObject] yn_x] + ([[self.itemsArrayM firstObject] yn_width]  - ([self.itemsWidthArraM.firstObject floatValue])) / 2;
         lineW = [self.itemsWidthArraM.firstObject floatValue];
     }
     
-    /// conver
-    if (self.configration.showConver) {
-        self.converView.frame = CGRectMake(lineX - kYNPageScrollMenuViewConverMarginX, (self.scrollView.yn_height - self.configration.converHeight - self.configration.lineHeight) * 0.5, lineW + kYNPageScrollMenuViewConverMarginW, self.configration.converHeight);
-        [self.scrollView insertSubview:self.converView atIndex:0];
+    /// cover
+    if (self.configuration.showCover) {
+        self.coverView.frame = CGRectMake(lineX - kYNPageScrollMenuViewCoverMarginX, (self.scrollView.yn_height - self.configuration.coverHeight - self.configuration.lineHeight) * 0.5, lineW + kYNPageScrollMenuViewCoverMarginW, self.configuration.coverHeight);
+        [self.scrollView insertSubview:self.coverView atIndex:0];
     }
     
     /// bottomLine
-    if (self.configration.showBottomLine) {
+    if (self.configuration.showBottomLine) {
         self.bottomLine = [[UIView alloc] init];
-        self.bottomLine.backgroundColor = self.configration.bottomLineBgColor;
-        self.bottomLine.frame = CGRectMake(self.configration.bottomLineLeftAndRightMargin, self.yn_height - self.configration.bottomLineHeight, self.scrollView.yn_width - 2 * self.configration.bottomLineLeftAndRightMargin, self.configration.bottomLineHeight);
-        self.bottomLine.layer.cornerRadius = self.configration.bottomLineCorner;
+        self.bottomLine.backgroundColor = self.configuration.bottomLineBgColor;
+        self.bottomLine.frame = CGRectMake(self.configuration.bottomLineLeftAndRightMargin, self.yn_height - self.configuration.bottomLineHeight, self.scrollView.yn_width - 2 * self.configuration.bottomLineLeftAndRightMargin, self.configuration.bottomLineHeight);
+        self.bottomLine.layer.cornerRadius = self.configuration.bottomLineCorner;
         [self insertSubview:self.bottomLine atIndex:0];
     }
     
     /// scrollLine
-    if (self.configration.showScrollLine) {
-        self.lineView.frame = CGRectMake(lineX - self.configration.lineLeftAndRightAddWidth + self.configration.lineLeftAndRightMargin, lineY - self.configration.lineBottomMargin, lineW + self.configration.lineLeftAndRightAddWidth * 2 - 2 * self.configration.lineLeftAndRightMargin, lineH);
-        self.lineView.layer.cornerRadius = self.configration.lineCorner;
+    if (self.configuration.showScrollLine) {
+        self.lineView.frame = CGRectMake(lineX - self.configuration.lineLeftAndRightAddWidth + self.configuration.lineLeftAndRightMargin, lineY - self.configuration.lineBottomMargin, lineW + self.configuration.lineLeftAndRightAddWidth * 2 - 2 * self.configuration.lineLeftAndRightMargin, lineH);
+        self.lineView.layer.cornerRadius = self.configuration.lineCorner;
         [self.scrollView addSubview:self.lineView];
     }
     
-    if (self.configration.itemMaxScale > 1) {
-        ((UIButton *)self.itemsArrayM[self.currentIndex]).transform = CGAffineTransformMakeScale(self.configration.itemMaxScale, self.configration.itemMaxScale);
+    if (self.configuration.itemMaxScale > 1) {
+        ((UIButton *)self.itemsArrayM[self.currentIndex]).transform = CGAffineTransformMakeScale(self.configuration.itemMaxScale, self.configuration.itemMaxScale);
     }
     [self setDefaultTheme];
     [self selectedItemIndex:self.currentIndex animated:NO];
@@ -208,35 +208,35 @@
 - (void)setDefaultTheme {
     UIButton *currentButton = self.itemsArrayM[self.currentIndex];
     /// 缩放
-    if (self.configration.itemMaxScale > 1) {
-        currentButton.transform = CGAffineTransformMakeScale(self.configration.itemMaxScale, self.configration.itemMaxScale);
+    if (self.configuration.itemMaxScale > 1) {
+        currentButton.transform = CGAffineTransformMakeScale(self.configuration.itemMaxScale, self.configuration.itemMaxScale);
     }
     /// 颜色
     currentButton.selected = YES;
-    [currentButton setTitleColor:self.configration.selectedItemColor forState:UIControlStateNormal];
-    currentButton.titleLabel.font = self.configration.selectedItemFont;
+    [currentButton setTitleColor:self.configuration.selectedItemColor forState:UIControlStateNormal];
+    currentButton.titleLabel.font = self.configuration.selectedItemFont;
     /// 线条
-    if (self.configration.showScrollLine) {
-        self.lineView.yn_x = currentButton.yn_x - self.configration.lineLeftAndRightAddWidth + self.configration.lineLeftAndRightMargin;
-        self.lineView.yn_width = currentButton.yn_width + self.configration.lineLeftAndRightAddWidth *2 - self.configration.lineLeftAndRightMargin * 2;
+    if (self.configuration.showScrollLine) {
+        self.lineView.yn_x = currentButton.yn_x - self.configuration.lineLeftAndRightAddWidth + self.configuration.lineLeftAndRightMargin;
+        self.lineView.yn_width = currentButton.yn_width + self.configuration.lineLeftAndRightAddWidth *2 - self.configuration.lineLeftAndRightMargin * 2;
         /// 处理Line宽度等于字体宽度
-        if (!self.configration.scrollMenu &&
-            !self.configration.aligmentModeCenter &&
-            self.configration.lineWidthEqualFontWidth) {
-            self.lineView.yn_x = currentButton.yn_x + ([currentButton yn_width]  - ([self.itemsWidthArraM[currentButton.tag] floatValue])) / 2 - self.configration.lineLeftAndRightAddWidth - self.configration.lineLeftAndRightAddWidth;
-            self.lineView.yn_width = [self.itemsWidthArraM[currentButton.tag] floatValue] + self.configration.lineLeftAndRightAddWidth *2;
+        if (!self.configuration.scrollMenu &&
+            !self.configuration.alignmentModeCenter &&
+            self.configuration.lineWidthEqualFontWidth) {
+            self.lineView.yn_x = currentButton.yn_x + ([currentButton yn_width]  - ([self.itemsWidthArraM[currentButton.tag] floatValue])) / 2 - self.configuration.lineLeftAndRightAddWidth - self.configuration.lineLeftAndRightAddWidth;
+            self.lineView.yn_width = [self.itemsWidthArraM[currentButton.tag] floatValue] + self.configuration.lineLeftAndRightAddWidth *2;
         }
     }
     /// 遮盖
-    if (self.configration.showConver) {
-        self.converView.yn_x = currentButton.yn_x - kYNPageScrollMenuViewConverMarginX;
-        self.converView.yn_width = currentButton.yn_width +kYNPageScrollMenuViewConverMarginW;
-        /// 处理conver宽度等于字体宽度
-        if (!self.configration.scrollMenu &&
-            !self.configration.aligmentModeCenter &&
-            self.configration.lineWidthEqualFontWidth) {
-            self.converView.yn_x = currentButton.yn_x + ([currentButton yn_width]  - ([self.itemsWidthArraM[currentButton.tag] floatValue])) / 2 - kYNPageScrollMenuViewConverMarginX;
-            self.converView.yn_width = [self.itemsWidthArraM[currentButton.tag] floatValue] + kYNPageScrollMenuViewConverMarginW;
+    if (self.configuration.showCover) {
+        self.coverView.yn_x = currentButton.yn_x - kYNPageScrollMenuViewCoverMarginX;
+        self.coverView.yn_width = currentButton.yn_width +kYNPageScrollMenuViewCoverMarginW;
+        /// 处理cover宽度等于字体宽度
+        if (!self.configuration.scrollMenu &&
+            !self.configuration.alignmentModeCenter &&
+            self.configuration.lineWidthEqualFontWidth) {
+            self.coverView.yn_x = currentButton.yn_x + ([currentButton yn_width]  - ([self.itemsWidthArraM[currentButton.tag] floatValue])) / 2 - kYNPageScrollMenuViewCoverMarginX;
+            self.coverView.yn_width = [self.itemsWidthArraM[currentButton.tag] floatValue] + kYNPageScrollMenuViewCoverMarginW;
         }
     }
     self.lastIndex = self.currentIndex;
@@ -247,43 +247,43 @@
     UIButton *currentButton = self.itemsArrayM[self.currentIndex];
     [UIView animateWithDuration:animated ? 0.3 : 0 animations:^{
         /// 缩放
-        if (self.configration.itemMaxScale > 1) {
+        if (self.configuration.itemMaxScale > 1) {
             lastButton.transform = CGAffineTransformMakeScale(1, 1);
-            currentButton.transform = CGAffineTransformMakeScale(self.configration.itemMaxScale, self.configration.itemMaxScale);
+            currentButton.transform = CGAffineTransformMakeScale(self.configuration.itemMaxScale, self.configuration.itemMaxScale);
         }
         /// 颜色
         [self.itemsArrayM enumerateObjectsUsingBlock:^(UIButton  * obj, NSUInteger idx, BOOL * _Nonnull stop) {
             obj.selected = NO;
-            [obj setTitleColor:self.configration.normalItemColor forState:UIControlStateNormal];
-            obj.titleLabel.font = self.configration.itemFont;
+            [obj setTitleColor:self.configuration.normalItemColor forState:UIControlStateNormal];
+            obj.titleLabel.font = self.configuration.itemFont;
             if (idx == self.itemsArrayM.count - 1) {
                currentButton.selected = YES;
-               [currentButton setTitleColor:self.configration.selectedItemColor forState:UIControlStateNormal];
-                currentButton.titleLabel.font = self.configration.selectedItemFont;
+               [currentButton setTitleColor:self.configuration.selectedItemColor forState:UIControlStateNormal];
+                currentButton.titleLabel.font = self.configuration.selectedItemFont;
             }
         }];
         
         /// 线条
-        if (self.configration.showScrollLine) {
-            self.lineView.yn_x = currentButton.yn_x - self.configration.lineLeftAndRightAddWidth + self.configration.lineLeftAndRightMargin;
-            self.lineView.yn_width = currentButton.yn_width + self.configration.lineLeftAndRightAddWidth * 2 - 2 * self.configration.lineLeftAndRightMargin;
+        if (self.configuration.showScrollLine) {
+            self.lineView.yn_x = currentButton.yn_x - self.configuration.lineLeftAndRightAddWidth + self.configuration.lineLeftAndRightMargin;
+            self.lineView.yn_width = currentButton.yn_width + self.configuration.lineLeftAndRightAddWidth * 2 - 2 * self.configuration.lineLeftAndRightMargin;
             
-            if (!self.configration.scrollMenu &&
-                !self.configration.aligmentModeCenter &&
-                self.configration.lineWidthEqualFontWidth) {//处理Line宽度等于字体宽度
+            if (!self.configuration.scrollMenu &&
+                !self.configuration.alignmentModeCenter &&
+                self.configuration.lineWidthEqualFontWidth) {//处理Line宽度等于字体宽度
                 
-                self.lineView.yn_x = currentButton.yn_x + ([currentButton yn_width]  - ([self.itemsWidthArraM[currentButton.tag] floatValue])) / 2 - self.configration.lineLeftAndRightAddWidth;;
-                self.lineView.yn_width = [self.itemsWidthArraM[currentButton.tag] floatValue] + self.configration.lineLeftAndRightAddWidth *2;
+                self.lineView.yn_x = currentButton.yn_x + ([currentButton yn_width]  - ([self.itemsWidthArraM[currentButton.tag] floatValue])) / 2 - self.configuration.lineLeftAndRightAddWidth;;
+                self.lineView.yn_width = [self.itemsWidthArraM[currentButton.tag] floatValue] + self.configuration.lineLeftAndRightAddWidth *2;
             }
         }
         /// 遮盖
-        if (self.configration.showConver) {
-            self.converView.yn_x = currentButton.yn_x - kYNPageScrollMenuViewConverMarginX;
-            self.converView.yn_width = currentButton.yn_width +kYNPageScrollMenuViewConverMarginW;
-            /// 处理conver宽度等于字体宽度
-            if (!self.configration.scrollMenu&&!self.configration.aligmentModeCenter&&self.configration.lineWidthEqualFontWidth) {
-                self.converView.yn_x = currentButton.yn_x + ([currentButton yn_width]  - ([self.itemsWidthArraM[currentButton.tag] floatValue])) / 2  - kYNPageScrollMenuViewConverMarginX;
-                self.converView.yn_width = [self.itemsWidthArraM[currentButton.tag] floatValue] +kYNPageScrollMenuViewConverMarginW;
+        if (self.configuration.showCover) {
+            self.coverView.yn_x = currentButton.yn_x - kYNPageScrollMenuViewCoverMarginX;
+            self.coverView.yn_width = currentButton.yn_width +kYNPageScrollMenuViewCoverMarginW;
+            /// 处理cover宽度等于字体宽度
+            if (!self.configuration.scrollMenu&&!self.configuration.alignmentModeCenter&&self.configuration.lineWidthEqualFontWidth) {
+                self.coverView.yn_x = currentButton.yn_x + ([currentButton yn_width]  - ([self.itemsWidthArraM[currentButton.tag] floatValue])) / 2  - kYNPageScrollMenuViewCoverMarginX;
+                self.coverView.yn_width = [self.itemsWidthArraM[currentButton.tag] floatValue] +kYNPageScrollMenuViewCoverMarginW;
             }
         }
         self.lastIndex = self.currentIndex;
@@ -334,18 +334,18 @@
     UIButton *currentButton = self.itemsArrayM[self.currentIndex];
     
     /// 缩放系数
-    if (self.configration.itemMaxScale > 1) {
-        CGFloat scaleB = self.configration.itemMaxScale - self.configration.deltaScale * progress;
-        CGFloat scaleS = 1 + self.configration.deltaScale * progress;
+    if (self.configuration.itemMaxScale > 1) {
+        CGFloat scaleB = self.configuration.itemMaxScale - self.configuration.deltaScale * progress;
+        CGFloat scaleS = 1 + self.configuration.deltaScale * progress;
         lastButton.transform = CGAffineTransformMakeScale(scaleB, scaleB);
         currentButton.transform = CGAffineTransformMakeScale(scaleS, scaleS);
     }
     
-    if (self.configration.showGradientColor) {
+    if (self.configuration.showGradientColor) {
         /// 颜色渐变
-        [self.configration setRGBWithProgress:progress];
-        UIColor *norColor = [UIColor colorWithRed:self.configration.deltaNorR green:self.configration.deltaNorG blue:self.configration.deltaNorB alpha:1];
-        UIColor *selColor = [UIColor colorWithRed:self.configration.deltaSelR green:self.configration.deltaSelG blue:self.configration.deltaSelB alpha:1];
+        [self.configuration setRGBWithProgress:progress];
+        UIColor *norColor = [UIColor colorWithRed:self.configuration.deltaNorR green:self.configuration.deltaNorG blue:self.configuration.deltaNorB alpha:1];
+        UIColor *selColor = [UIColor colorWithRed:self.configuration.deltaSelR green:self.configuration.deltaSelG blue:self.configuration.deltaSelB alpha:1];
         [lastButton setTitleColor:norColor forState:UIControlStateNormal];
         [currentButton setTitleColor:selColor forState:UIControlStateNormal];
         
@@ -353,32 +353,32 @@
         if (progress > 0.5) {
             lastButton.selected = NO;
             currentButton.selected = YES;
-            [lastButton setTitleColor:self.configration.normalItemColor forState:UIControlStateNormal];
-            [currentButton setTitleColor:self.configration.selectedItemColor forState:UIControlStateNormal];
-            currentButton.titleLabel.font = self.configration.selectedItemFont;
+            [lastButton setTitleColor:self.configuration.normalItemColor forState:UIControlStateNormal];
+            [currentButton setTitleColor:self.configuration.selectedItemColor forState:UIControlStateNormal];
+            currentButton.titleLabel.font = self.configuration.selectedItemFont;
         } else if (progress < 0.5 && progress > 0){
             lastButton.selected = YES;
-            [lastButton setTitleColor:self.configration.selectedItemColor forState:UIControlStateNormal];
-            lastButton.titleLabel.font = self.configration.selectedItemFont;
+            [lastButton setTitleColor:self.configuration.selectedItemColor forState:UIControlStateNormal];
+            lastButton.titleLabel.font = self.configuration.selectedItemFont;
             currentButton.selected = NO;
-            [currentButton setTitleColor:self.configration.normalItemColor forState:UIControlStateNormal];
-            currentButton.titleLabel.font = self.configration.itemFont;
+            [currentButton setTitleColor:self.configuration.normalItemColor forState:UIControlStateNormal];
+            currentButton.titleLabel.font = self.configuration.itemFont;
         }
     }
     
     if (progress > 0.5) {
-        lastButton.titleLabel.font = self.configration.itemFont;
-        currentButton.titleLabel.font = self.configration.selectedItemFont;
+        lastButton.titleLabel.font = self.configuration.itemFont;
+        currentButton.titleLabel.font = self.configuration.selectedItemFont;
     } else if (progress < 0.5 && progress > 0){
-        lastButton.titleLabel.font = self.configration.selectedItemFont;
-        currentButton.titleLabel.font = self.configration.itemFont;
+        lastButton.titleLabel.font = self.configuration.selectedItemFont;
+        currentButton.titleLabel.font = self.configuration.itemFont;
     }
     
     CGFloat xD = 0;
     CGFloat wD = 0;
-    if (!self.configration.scrollMenu &&
-        !self.configration.aligmentModeCenter &&
-        self.configration.lineWidthEqualFontWidth) {
+    if (!self.configuration.scrollMenu &&
+        !self.configuration.alignmentModeCenter &&
+        self.configuration.lineWidthEqualFontWidth) {
         xD = currentButton.titleLabel.yn_x + currentButton.yn_x -( lastButton.titleLabel.yn_x + lastButton.yn_x );
         wD = currentButton.titleLabel.yn_width - lastButton.titleLabel.yn_width;
     } else {
@@ -387,30 +387,30 @@
     }
     
     /// 线条
-    if (self.configration.showScrollLine) {
+    if (self.configuration.showScrollLine) {
         
-        if (!self.configration.scrollMenu &&
-            !self.configration.aligmentModeCenter &&
-            self.configration.lineWidthEqualFontWidth) { /// 处理Line宽度等于字体宽度
-            self.lineView.yn_x = lastButton.yn_x + ([lastButton yn_width]  - ([self.itemsWidthArraM[lastButton.tag] floatValue])) / 2 - self.configration.lineLeftAndRightAddWidth + xD *progress;
+        if (!self.configuration.scrollMenu &&
+            !self.configuration.alignmentModeCenter &&
+            self.configuration.lineWidthEqualFontWidth) { /// 处理Line宽度等于字体宽度
+            self.lineView.yn_x = lastButton.yn_x + ([lastButton yn_width]  - ([self.itemsWidthArraM[lastButton.tag] floatValue])) / 2 - self.configuration.lineLeftAndRightAddWidth + xD *progress;
             
-            self.lineView.yn_width = [self.itemsWidthArraM[lastButton.tag] floatValue] + self.configration.lineLeftAndRightAddWidth *2 + wD *progress;
+            self.lineView.yn_width = [self.itemsWidthArraM[lastButton.tag] floatValue] + self.configuration.lineLeftAndRightAddWidth *2 + wD *progress;
             
         } else {
-            self.lineView.yn_x = lastButton.yn_x + xD *progress - self.configration.lineLeftAndRightAddWidth + self.configration.lineLeftAndRightMargin;
-            self.lineView.yn_width = lastButton.yn_width + wD *progress + self.configration.lineLeftAndRightAddWidth *2 - 2 * self.configration.lineLeftAndRightMargin;
+            self.lineView.yn_x = lastButton.yn_x + xD *progress - self.configuration.lineLeftAndRightAddWidth + self.configuration.lineLeftAndRightMargin;
+            self.lineView.yn_width = lastButton.yn_width + wD *progress + self.configuration.lineLeftAndRightAddWidth *2 - 2 * self.configuration.lineLeftAndRightMargin;
         }
     }
     /// 遮盖
-    if (self.configration.showConver) {
-        self.converView.yn_x = lastButton.yn_x + xD *progress - kYNPageScrollMenuViewConverMarginX;
-        self.converView.yn_width = lastButton.yn_width  + wD *progress + kYNPageScrollMenuViewConverMarginW;
+    if (self.configuration.showCover) {
+        self.coverView.yn_x = lastButton.yn_x + xD *progress - kYNPageScrollMenuViewCoverMarginX;
+        self.coverView.yn_width = lastButton.yn_width  + wD *progress + kYNPageScrollMenuViewCoverMarginW;
         
-        if (!self.configration.scrollMenu &&
-            !self.configration.aligmentModeCenter &&
-            self.configration.lineWidthEqualFontWidth) { /// 处理cover宽度等于字体宽度
-            self.converView.yn_x = lastButton.yn_x + ([lastButton yn_width]  - ([self.itemsWidthArraM[lastButton.tag] floatValue])) / 2 -  kYNPageScrollMenuViewConverMarginX + xD *progress;
-            self.converView.yn_width = [self.itemsWidthArraM[lastButton.tag] floatValue] + kYNPageScrollMenuViewConverMarginW + wD *progress;
+        if (!self.configuration.scrollMenu &&
+            !self.configuration.alignmentModeCenter &&
+            self.configuration.lineWidthEqualFontWidth) { /// 处理cover宽度等于字体宽度
+            self.coverView.yn_x = lastButton.yn_x + ([lastButton yn_width]  - ([self.itemsWidthArraM[lastButton.tag] floatValue])) / 2 -  kYNPageScrollMenuViewCoverMarginX + xD *progress;
+            self.coverView.yn_width = [self.itemsWidthArraM[lastButton.tag] floatValue] + kYNPageScrollMenuViewCoverMarginW + wD *progress;
         }
     }
 }
@@ -430,30 +430,30 @@
 - (UIView *)lineView {
     if (!_lineView) {
         _lineView = [[UIView alloc]init];
-        _lineView.backgroundColor = self.configration.lineColor;
+        _lineView.backgroundColor = self.configuration.lineColor;
     }
     return _lineView;
 }
 
-- (UIView *)converView {
-    if (!_converView) {
-        _converView = [[UIView alloc] init];
-        _converView.layer.backgroundColor = self.configration.converColor.CGColor;
-        _converView.layer.cornerRadius = self.configration.coverCornerRadius;
-        _converView.layer.masksToBounds = YES;
-        _converView.userInteractionEnabled = NO;
+- (UIView *)coverView {
+    if (!_coverView) {
+        _coverView = [[UIView alloc] init];
+        _coverView.layer.backgroundColor = self.configuration.coverColor.CGColor;
+        _coverView.layer.cornerRadius = self.configuration.coverCornerRadius;
+        _coverView.layer.masksToBounds = YES;
+        _coverView.userInteractionEnabled = NO;
     }
-    return _converView;
+    return _coverView;
 }
 
 - (UIScrollView *)scrollView {
     if (!_scrollView) {
         _scrollView = [[YNPageScrollView alloc] init];
         _scrollView.pagingEnabled = NO;
-        _scrollView.bounces = self.configration.bounces;;
+        _scrollView.bounces = self.configuration.bounces;;
         _scrollView.showsVerticalScrollIndicator = NO;
         _scrollView.showsHorizontalScrollIndicator = NO;
-        _scrollView.scrollEnabled = self.configration.scrollMenu;
+        _scrollView.scrollEnabled = self.configuration.scrollMenu;
     }
     return _scrollView;
 }
@@ -461,12 +461,12 @@
 - (UIButton *)addButton {
     if (!_addButton) {
         _addButton = [[UIButton alloc] init];
-        [_addButton setBackgroundImage:[UIImage imageNamed:self.configration.addButtonNormalImageName] forState:UIControlStateNormal];
-        [_addButton setBackgroundImage:[UIImage imageNamed:self.configration.addButtonHightImageName] forState:UIControlStateHighlighted];
+        [_addButton setBackgroundImage:[UIImage imageNamed:self.configuration.addButtonNormalImageName] forState:UIControlStateNormal];
+        [_addButton setBackgroundImage:[UIImage imageNamed:self.configuration.addButtonHightImageName] forState:UIControlStateHighlighted];
         _addButton.layer.shadowColor = [UIColor grayColor].CGColor;
         _addButton.layer.shadowOffset = CGSizeMake(-1, 0);
         _addButton.layer.shadowOpacity = 0.5;
-        _addButton.backgroundColor = self.configration.addButtonBackgroundColor;
+        _addButton.backgroundColor = self.configuration.addButtonBackgroundColor;
         [_addButton addTarget:self action:@selector(addButtonAction:) forControlEvents:UIControlEventTouchUpInside];
     }
     return _addButton;
@@ -476,8 +476,8 @@
 - (void)itemButtonOnClick:(UIButton *)button {
     self.currentIndex= button.tag;
     [self adjustItemWithAnimated:YES];
-    if (self.delegate &&[self.delegate respondsToSelector:@selector(pagescrollMenuViewItemOnClick:index:)]) {
-        [self.delegate pagescrollMenuViewItemOnClick:button index:self.lastIndex];
+    if (self.delegate &&[self.delegate respondsToSelector:@selector(pageScrollMenuViewItemOnClick:index:)]) {
+        [self.delegate pageScrollMenuViewItemOnClick:button index:self.lastIndex];
     }
 }
 
@@ -497,8 +497,8 @@
 
 #pragma mark -  addButtonAction
 - (void)addButtonAction:(UIButton *)button {
-    if(self.delegate && [self.delegate respondsToSelector:@selector(pagescrollMenuViewAddButtonAction:)]){
-        [self.delegate pagescrollMenuViewAddButtonAction:button];
+    if(self.delegate && [self.delegate respondsToSelector:@selector(pageScrollMenuViewAddButtonAction:)]){
+        [self.delegate pageScrollMenuViewAddButtonAction:button];
     }
 }
 

--- a/YNPageViewController/YNPageViewController/Libs/YNPageViewController/YNPageConfiguration.h
+++ b/YNPageViewController/YNPageViewController/Libs/YNPageViewController/YNPageConfiguration.h
@@ -37,19 +37,19 @@ typedef NS_ENUM(NSInteger, YNPageHeaderViewScaleMode) {
     YNPageHeaderViewScaleModeCenter = 1,
 };
 
-@interface YNPageConfigration : NSObject
+@interface YNPageConfiguration : NSObject
 
 #pragma mark - YNPage Config
 /** 是否显示导航条 YES */
 @property (nonatomic, assign) BOOL showNavigation;
 /** 是否显示Tabbar NO */
-@property (nonatomic, assign) BOOL showTabbar;
+@property (nonatomic, assign) BOOL showTabBar;
 /** 裁剪内容高度 用来添加最上层控件 添加在父类view上 */
 @property (nonatomic, assign) CGFloat cutOutHeight;
 /** 菜单位置风格 默认 YNPageStyleTop */
 @property (nonatomic, assign) YNPageStyle pageStyle;
 /** 悬浮ScrollMenu偏移量 默认 0 */
-@property (nonatomic, assign) CGFloat suspenOffsetY;
+@property (nonatomic, assign) CGFloat suspendOffsetY;
 /** 页面是否可以滚动 默认 YES */
 @property (nonatomic, assign) BOOL pageScrollEnabled;
 /** 头部是否能伸缩效果   要伸缩效果最好不要有下拉刷新控件 NO */
@@ -63,7 +63,7 @@ typedef NS_ENUM(NSInteger, YNPageHeaderViewScaleMode) {
 
 #pragma mark - UIScrollMenuView Config
 /** 是否显示遮盖*/
-@property (nonatomic, assign) BOOL showConver;
+@property (nonatomic, assign) BOOL showCover;
 /** 是否显示线条 YES */
 @property (nonatomic, assign) BOOL showScrollLine;
 /** 是否显示底部线条 NO */
@@ -78,9 +78,9 @@ typedef NS_ENUM(NSInteger, YNPageHeaderViewScaleMode) {
 @property (nonatomic, assign) BOOL bounces;
 /**
  *  是否是居中 (当所有的Item+margin的宽度小于ScrollView宽度)  默认 YES
- *  scrollMenu = NO,aligmentModeCenter = NO 会变成平分
+ *  scrollMenu = NO,alignmentModeCenter = NO 会变成平分
  */
-@property (nonatomic, assign) BOOL aligmentModeCenter;
+@property (nonatomic, assign) BOOL alignmentModeCenter;
 /** 当aligmentModeCenter 变为平分时 是否需要线条宽度等于字体宽度 默认 NO */
 @property (nonatomic, assign) BOOL lineWidthEqualFontWidth;
 /** 自定义Item 加图片 图片间隙 ... */
@@ -94,7 +94,7 @@ typedef NS_ENUM(NSInteger, YNPageHeaderViewScaleMode) {
 /** 线条color */
 @property (nonatomic, strong) UIColor *lineColor;
 /** 遮盖color */
-@property (nonatomic, strong) UIColor *converColor;
+@property (nonatomic, strong) UIColor *coverColor;
 /** 菜单背景color */
 @property (nonatomic, strong) UIColor *scrollViewBackgroundColor;
 /** 选项正常color */
@@ -120,10 +120,10 @@ typedef NS_ENUM(NSInteger, YNPageHeaderViewScaleMode) {
 /** 底部线height 2 */
 @property (nonatomic, assign) CGFloat bottomLineHeight;
 /** 遮盖height 28 */
-@property (nonatomic, assign) CGFloat converHeight;
+@property (nonatomic, assign) CGFloat coverHeight;
 /** 菜单height 默认 44 */
 @property (nonatomic, assign) CGFloat menuHeight;
-/** 菜单widht 默认是 屏幕宽度 */
+/** 菜单width 默认是 屏幕宽度 */
 @property (nonatomic, assign) CGFloat menuWidth;
 /** 遮盖圆角 14 */
 @property (nonatomic, assign) CGFloat coverCornerRadius;

--- a/YNPageViewController/YNPageViewController/Libs/YNPageViewController/YNPageConfiguration.m
+++ b/YNPageViewController/YNPageViewController/Libs/YNPageViewController/YNPageConfiguration.m
@@ -6,10 +6,10 @@
 //  Copyright © 2018年 yongneng. All rights reserved.
 //
 
-#import "YNPageConfigration.h"
+#import "YNPageConfiguration.h"
 #import "UIView+YNPageExtend.h"
 
-@interface YNPageConfigration ()
+@interface YNPageConfiguration ()
 
 @property (nonatomic, strong) NSArray *normalColorArrays;
 
@@ -19,22 +19,22 @@
 
 @end
 
-@implementation YNPageConfigration
+@implementation YNPageConfiguration
 
 - (instancetype)init {
     self = [super init];
     if (self) {
         _showNavigation = YES;
-        _showTabbar = NO;
+        _showTabBar = NO;
         _pageStyle = YNPageStyleTop;
-        _showConver = NO;
+        _showCover = NO;
         _showScrollLine = YES;
         _showBottomLine = NO;
         _showGradientColor =YES;
         _showAddButton = NO;
         _scrollMenu = YES;
         _bounces = YES;
-        _aligmentModeCenter = YES;
+        _alignmentModeCenter = YES;
         _lineWidthEqualFontWidth = NO;
         
         _pageScrollEnabled = YES;
@@ -42,14 +42,14 @@
         _headerViewCouldScale = NO;
         
         _lineColor = [UIColor redColor];
-        _converColor = [UIColor groupTableViewBackgroundColor];
+        _coverColor = [UIColor groupTableViewBackgroundColor];
         _addButtonBackgroundColor = [UIColor whiteColor];
         _bottomLineBgColor = [UIColor greenColor];
         _scrollViewBackgroundColor = [UIColor whiteColor];
         _normalItemColor = [UIColor grayColor];
         _selectedItemColor = [UIColor greenColor];
         _lineHeight = 2;
-        _converHeight = 28;
+        _coverHeight = 28;
         
         _menuHeight = 44;
         _menuWidth = kYNPAGE_SCREEN_WIDTH;

--- a/YNPageViewController/YNPageViewController/Libs/YNPageViewController/YNPageViewController.h
+++ b/YNPageViewController/YNPageViewController/Libs/YNPageViewController/YNPageViewController.h
@@ -7,7 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "YNPageConfigration.h"
+#import "YNPageConfiguration.h"
 #import "YNPageScrollMenuView.h"
 #import "YNPageScrollView.h"
 
@@ -115,7 +115,7 @@
 @interface YNPageViewController : UIViewController
 
 /// 配置信息
-@property (nonatomic, strong) YNPageConfigration *config;
+@property (nonatomic, strong) YNPageConfiguration *config;
 /// 控制器数组
 @property (nonatomic, strong) NSMutableArray<__kindof UIViewController *> *controllersM;
 /// 标题数组 默认 缓存 key 为 title 可通过数据源代理 进行替换
@@ -149,7 +149,7 @@
  */
 + (instancetype)pageViewControllerWithControllers:(NSArray *)controllers
                                            titles:(NSArray *)titles
-                                           config:(YNPageConfigration *)config;
+                                           config:(YNPageConfiguration *)config;
 /**
  初始化方法
  @param controllers 子控制器
@@ -158,13 +158,13 @@
  */
 - (instancetype)initPageViewControllerWithControllers:(NSArray *)controllers
                                                titles:(NSArray *)titles
-                                               config:(YNPageConfigration *)config;
+                                               config:(YNPageConfiguration *)config;
 
 /**
  *  当前PageScrollViewVC作为子控制器
- *  @param parentViewControler 父类控制器
+ *  @param parentViewController 父类控制器
  */
-- (void)addSelfToParentViewController:(UIViewController *)parentViewControler;
+- (void)addSelfToParentViewController:(UIViewController *)parentViewController;
 
 /**
  *  从父类控制器里面移除自己（PageScrollViewVC）

--- a/YNPageViewController/YNPageViewController/Libs/YNPageViewController/YNPageViewController.m
+++ b/YNPageViewController/YNPageViewController/Libs/YNPageViewController/YNPageViewController.m
@@ -28,7 +28,7 @@
 /// 字典控制器的缓存
 @property (nonatomic, strong) NSMutableDictionary *cacheDictM;
 /// 字典ScrollView的缓存
-@property (nonatomic, strong) NSMutableDictionary *scrollViewCacheDictionryM;
+@property (nonatomic, strong) NSMutableDictionary *scrollViewCacheDictionaryM;
 /// 当前显示的页面
 @property (nonatomic, strong) UIScrollView *currentScrollView;
 /// 当前控制器
@@ -44,7 +44,7 @@
 /// headerView的原始高度 用来处理头部伸缩效果
 @property (nonatomic, assign) CGFloat headerViewOriginHeight;
 /// 是否是悬浮状态
-@property (nonatomic, assign) BOOL supendStatus;
+@property (nonatomic, assign) BOOL suspendStatus;
 /// 记录bgScrollView Y 偏移量
 @property (nonatomic, assign) CGFloat beginBgScrollOffsetY;
 /// 记录currentScrollView Y 偏移量
@@ -72,7 +72,7 @@
  */
 + (instancetype)pageViewControllerWithControllers:(NSArray *)controllers
                                            titles:(NSArray *)titles
-                                           config:(YNPageConfigration *)config {
+                                           config:(YNPageConfiguration *)config {
     return [[self alloc] initPageViewControllerWithControllers:controllers
                                                         titles:titles
                                                         config:config];
@@ -80,25 +80,25 @@
 
 - (instancetype)initPageViewControllerWithControllers:(NSArray *)controllers
                                                titles:(NSArray *)titles
-                                               config:(YNPageConfigration *)config {
+                                               config:(YNPageConfiguration *)config {
     self = [super init];
     self.controllersM = controllers.mutableCopy;
     self.titlesM = titles.mutableCopy;
-    self.config = config ?: [YNPageConfigration defaultConfig];
+    self.config = config ?: [YNPageConfiguration defaultConfig];
     self.displayDictM = @{}.mutableCopy;
     self.cacheDictM = @{}.mutableCopy;
     self.originInsetBottomDictM = @{}.mutableCopy;
-    self.scrollViewCacheDictionryM = @{}.mutableCopy;
+    self.scrollViewCacheDictionaryM = @{}.mutableCopy;
     return self;
 }
 
 /**
  *  当前PageScrollViewVC作为子控制器
  *
- *  @param parentViewControler 父类控制器
+ *  @param parentViewController 父类控制器
  */
-- (void)addSelfToParentViewController:(UIViewController *)parentViewControler {
-    [self addChildViewControllerWithChildVC:self parentVC:parentViewControler];
+- (void)addSelfToParentViewController:(UIViewController *)parentViewController {
+    [self addChildViewControllerWithChildVC:self parentVC:parentViewController];
 }
 
 /**
@@ -109,10 +109,10 @@
 }
 
 #pragma mark - 初始化PageScrollMenu
-- (void)initPagescrollMenuViewWithFrame:(CGRect)frame {
-    YNPageScrollMenuView *scrollMenuView = [YNPageScrollMenuView pagescrollMenuViewWithFrame:frame
+- (void)initPageScrollMenuViewWithFrame:(CGRect)frame {
+    YNPageScrollMenuView *scrollMenuView = [YNPageScrollMenuView pageScrollMenuViewWithFrame:frame
                                                                                       titles:self.titlesM
-                                                                                configration:self.config
+                                                                                configuration:self.config
                                                                                     delegate:self currentIndex:self.pageIndex];
     self.scrollMenuView = scrollMenuView;
     
@@ -200,14 +200,14 @@
         } else {
             CGFloat scrollMenuViewY = [self.scrollMenuView.superview convertRect:self.scrollMenuView.frame toView:self.view].origin.y;
             
-            if (self.supendStatus) {
+            if (self.suspendStatus) {
                 /// 首次已经悬浮 设置初始化 偏移量
                 if (![self.cacheDictM objectForKey:[self getKeyWithTitle:title]]) {
-                    [scrollView setContentOffset:CGPointMake(0, -self.config.menuHeight - self.config.suspenOffsetY) animated:NO];
+                    [scrollView setContentOffset:CGPointMake(0, -self.config.menuHeight - self.config.suspendOffsetY) animated:NO];
                 } else {
                     /// 再次悬浮 已经加载过 设置偏移量
-                    if (scrollView.contentOffset.y < -self.config.menuHeight - self.config.suspenOffsetY) {
-                        [scrollView setContentOffset:CGPointMake(0, -self.config.menuHeight - self.config.suspenOffsetY) animated:NO];
+                    if (scrollView.contentOffset.y < -self.config.menuHeight - self.config.suspendOffsetY) {
+                        [scrollView setContentOffset:CGPointMake(0, -self.config.menuHeight - self.config.suspendOffsetY) animated:NO];
                     }
                 }
             } else {
@@ -266,16 +266,16 @@
 /// scrollView滚动ing
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
     if (scrollView == self.bgScrollView) {
-        [self calcuSuspendTopPauseWithBgScrollView:scrollView];
+        [self calculateSuspendTopPauseWithBgScrollView:scrollView];
         [self invokeDelegateForScrollWithOffsetY:scrollView.contentOffset.y];
         return;
     }
     
-    CGFloat currentPostion = scrollView.contentOffset.x;
+    CGFloat currentPosition = scrollView.contentOffset.x;
 
-    CGFloat offsetX = currentPostion / kYNPAGE_SCREEN_WIDTH;
+    CGFloat offsetX = currentPosition / kYNPAGE_SCREEN_WIDTH;
 
-    CGFloat offX = currentPostion > self.lastPositionX ? ceilf(offsetX) : offsetX;
+    CGFloat offX = currentPosition > self.lastPositionX ? ceilf(offsetX) : offsetX;
 
     [self replaceHeaderViewFromTableView];
     
@@ -283,7 +283,7 @@
 
     CGFloat progress = offsetX - (NSInteger)offsetX;
 
-    self.lastPositionX = currentPostion;
+    self.lastPositionX = currentPosition;
     
     [self.scrollMenuView adjustItemWithProgress:progress lastIndex:floor(offsetX) currentIndex:ceilf(offsetX)];
     
@@ -296,8 +296,8 @@
     }
 }
 
-#pragma mark - yn_pageScrollViewBeginDragginScrollView
-- (void)yn_pageScrollViewBeginDragginScrollView:(UIScrollView *)scrollView {
+#pragma mark - yn_pageScrollViewBeginDraggingScrollView
+- (void)yn_pageScrollViewBeginDraggingScrollView:(UIScrollView *)scrollView {
     _beginBgScrollOffsetY = self.bgScrollView.contentOffset.y;
     _beginCurrentScrollOffsetY = scrollView.contentOffset.y;
 }
@@ -318,10 +318,10 @@
         
         CGFloat offsetY = scrollView.contentOffset.y;
         /// 悬浮临界点
-        if (offsetY > - self.scrollMenuView.yn_height - self.config.suspenOffsetY) {
-            self.headerBgView.yn_y = -self.headerBgView.yn_height + offsetY + self.config.suspenOffsetY;
-            self.scrollMenuView.yn_y = offsetY + self.config.suspenOffsetY;
-            self.supendStatus = YES;
+        if (offsetY > - self.scrollMenuView.yn_height - self.config.suspendOffsetY) {
+            self.headerBgView.yn_y = -self.headerBgView.yn_height + offsetY + self.config.suspendOffsetY;
+            self.scrollMenuView.yn_y = offsetY + self.config.suspendOffsetY;
+            self.suspendStatus = YES;
         } else {
             /// headerView往下拉置顶
             if (offsetY >= -_insetTop) {
@@ -332,7 +332,7 @@
                 }
             }
             self.scrollMenuView.yn_y = self.headerBgView.yn_bottom;
-            self.supendStatus = NO;
+            self.suspendStatus = NO;
         }
         
         [self adjustSectionHeader:scrollView];
@@ -342,7 +342,7 @@
         [self headerScaleWithOffsetY:offsetY];
         
     } else if ([self isSuspensionTopPauseStyle]) {
-        [self calcuSuspendTopPauseWithCurrentScrollView:scrollView];
+        [self calculateSuspendTopPauseWithCurrentScrollView:scrollView];
     } else {
          [self invokeDelegateForScrollWithOffsetY:scrollView.contentOffset.y];
     }
@@ -357,14 +357,14 @@
 }
 
 #pragma mark - YNPageScrollMenuViewDelegate
-- (void)pagescrollMenuViewItemOnClick:(UIButton *)button index:(NSInteger)index {
+- (void)pageScrollMenuViewItemOnClick:(UIButton *)button index:(NSInteger)index {
     if (self.delegate && [self.delegate respondsToSelector:@selector(pageViewController:didScrollMenuItem:index:)]) {
         [self.delegate pageViewController:self didScrollMenuItem:button index:index];
     }
     [self setSelectedPageIndex:index];
 }
 
-- (void)pagescrollMenuViewAddButtonAction:(UIButton *)button {
+- (void)pageScrollMenuViewAddButtonAction:(UIButton *)button {
     if (self.delegate && [self.delegate respondsToSelector:@selector(pageViewController:didAddButtonAction:)]) {
         [self.delegate pageViewController:self didAddButtonAction:button];
     }
@@ -399,7 +399,7 @@
     
     [self.originInsetBottomDictM removeAllObjects];
     [self.cacheDictM removeAllObjects];
-    [self.scrollViewCacheDictionryM removeAllObjects];
+    [self.scrollViewCacheDictionaryM removeAllObjects];
     [self.headerBgView removeFromSuperview];
     [self.bgScrollView removeFromSuperview];
     [self.pageScrollView removeFromSuperview];
@@ -459,7 +459,7 @@
     if (titles.count == controllers.count && controllers.count > 0) {
         for (int i = 0; i < titles.count; i++) {
             NSString *title = titles[i];
-            if (title.length == 0 || ([self.titlesM containsObject:title] && ![self respondsToCustomCachekey])) {
+            if (title.length == 0 || ([self.titlesM containsObject:title] && ![self respondsToCustomCacheKey])) {
                 continue;
             }
             insertSuccess = YES;
@@ -494,7 +494,7 @@
 }
 
 - (void)removePageControllerWithTitle:(NSString *)title {
-    if ([self respondsToCustomCachekey]) return;
+    if ([self respondsToCustomCacheKey]) return;
     NSInteger index = -1;
     for (NSInteger i = 0; i < self.titlesM.count; i++) {
         if ([self.titlesM[i] isEqualToString:title]) {
@@ -527,7 +527,7 @@
     NSString *key = [self getKeyWithTitle:title];
     
     [self.originInsetBottomDictM removeObjectForKey:key];
-    [self.scrollViewCacheDictionryM removeObjectForKey:key];
+    [self.scrollViewCacheDictionaryM removeObjectForKey:key];
     [self.cacheDictM removeObjectForKey:key];
     
     [self updateViewWithIndex:pageIndex];
@@ -637,17 +637,17 @@
 /// 初始化PageScrollView
 - (void)setupPageScrollView {
     CGFloat navHeight = self.config.showNavigation ? kYNPAGE_NAVHEIGHT : 0;
-    CGFloat tabHeight = self.config.showTabbar ? kYNPAGE_TABBARHEIGHT : 0;
+    CGFloat tabHeight = self.config.showTabBar ? kYNPAGE_TABBARHEIGHT : 0;
     CGFloat cutOutHeight = self.config.cutOutHeight > 0 ? self.config.cutOutHeight : 0;
     CGFloat contentHeight = kYNPAGE_SCREEN_HEIGHT - navHeight - tabHeight - cutOutHeight;
     
     if ([self isSuspensionTopPauseStyle]) {
         self.bgScrollView.frame = CGRectMake(0, 0, kYNPAGE_SCREEN_WIDTH, contentHeight);
-        self.bgScrollView.contentSize = CGSizeMake(kYNPAGE_SCREEN_WIDTH, contentHeight + self.headerBgView.yn_height - self.config.suspenOffsetY);
+        self.bgScrollView.contentSize = CGSizeMake(kYNPAGE_SCREEN_WIDTH, contentHeight + self.headerBgView.yn_height - self.config.suspendOffsetY);
         
         self.scrollMenuView.yn_y = self.headerBgView.yn_bottom;
         
-        self.pageScrollView.frame = CGRectMake(0, self.scrollMenuView.yn_bottom, kYNPAGE_SCREEN_WIDTH, contentHeight - self.config.menuHeight  - self.config.suspenOffsetY);
+        self.pageScrollView.frame = CGRectMake(0, self.scrollMenuView.yn_bottom, kYNPAGE_SCREEN_WIDTH, contentHeight - self.config.menuHeight  - self.config.suspendOffsetY);
         
         self.pageScrollView.contentSize = CGSizeMake(kYNPAGE_SCREEN_WIDTH * self.controllersM.count, self.pageScrollView.yn_height);
         
@@ -675,7 +675,7 @@
 
 /// 初始化ScrollView
 - (void)setupPageScrollMenuView {
-    [self initPagescrollMenuViewWithFrame:CGRectMake(0, 0, self.config.menuWidth, self.config.menuHeight)];
+    [self initPageScrollMenuViewWithFrame:CGRectMake(0, 0, self.config.menuWidth, self.config.menuHeight)];
 }
 
 /// 初始化背景headerView
@@ -701,7 +701,7 @@
         _scrollMenuViewOriginY = _headerView.yn_height;
         
         if ([self isSuspensionTopPauseStyle]) {
-            _insetTop = self.headerBgView.yn_height - self.config.suspenOffsetY;
+            _insetTop = self.headerBgView.yn_height - self.config.suspendOffsetY;
             [self.bgScrollView addSubview:self.headerBgView];
         }
     }
@@ -754,7 +754,7 @@
 
 /// - 最终效果 current 拖到指定时 bg 才能下拉 ， bg 悬浮时 current 才能上拉
 /// 计算悬浮顶部偏移量 - BgScrollView
-- (void)calcuSuspendTopPauseWithBgScrollView:(UIScrollView *)scrollView {
+- (void)calculateSuspendTopPauseWithBgScrollView:(UIScrollView *)scrollView {
     if ([self isSuspensionTopPauseStyle] && scrollView == self.bgScrollView) {
         
         CGFloat bg_OffsetY = scrollView.contentOffset.y;
@@ -787,7 +787,7 @@
 }
 
 /// 计算悬浮顶部偏移量 - CurrentScrollView
-- (void)calcuSuspendTopPauseWithCurrentScrollView:(UIScrollView *)scrollView {
+- (void)calculateSuspendTopPauseWithCurrentScrollView:(UIScrollView *)scrollView {
     if ([self isSuspensionTopPauseStyle]) {
         if (!scrollView.isDragging) return;
         CGFloat bg_OffsetY = self.bgScrollView.contentOffset.y;
@@ -855,7 +855,7 @@
     
     NSAssert(self.controllersM.count == self.titlesM.count, @"ViewControllers`count is not equal titleArray!");
 #endif
-    if (![self respondsToCustomCachekey]) {
+    if (![self respondsToCustomCacheKey]) {
         BOOL isHasNotEqualTitle = YES;
         for (int i = 0; i < self.titlesM.count; i++) {
             for (int j = i + 1; j < self.titlesM.count; j++) {
@@ -871,7 +871,7 @@
     }
 }
 
-- (BOOL)respondsToCustomCachekey {
+- (BOOL)respondsToCustomCacheKey {
     if (self.dataSource && [self.dataSource respondsToSelector:@selector(pageViewController:customCacheKeyForIndex:)]) {
         return YES;
     }
@@ -908,7 +908,7 @@
 }
 
 - (NSString *)getKeyWithTitle:(NSString *)title {
-    if ([self respondsToCustomCachekey]) {
+    if ([self respondsToCustomCacheKey]) {
         NSString *ID = [self.dataSource pageViewController:self customCacheKeyForIndex:self.pageIndex];
         return ID;
     }
@@ -922,14 +922,14 @@
         switch (self.config.pageStyle) {
             case YNPageStyleSuspensionTop:
             case YNPageStyleSuspensionCenter: {
-                CGFloat progress = 1 + (offsetY + self.scrollMenuView.yn_height + self.config.suspenOffsetY) / (self.headerBgView.yn_height -self.config.suspenOffsetY);
+                CGFloat progress = 1 + (offsetY + self.scrollMenuView.yn_height + self.config.suspendOffsetY) / (self.headerBgView.yn_height -self.config.suspendOffsetY);
                 progress = progress > 1 ? 1 : progress;
                 progress = progress < 0 ? 0 : progress;
                 [self.delegate pageViewController:self contentOffsetY:offsetY progress:progress];
             }
                 break;
             case YNPageStyleSuspensionTopPause: {
-                CGFloat progress = offsetY / (self.headerBgView.yn_height - self.config.suspenOffsetY);
+                CGFloat progress = offsetY / (self.headerBgView.yn_height - self.config.suspendOffsetY);
                 progress = progress > 1 ? 1 : progress;
                 progress = progress < 0 ? 0 : progress;
                 [self.delegate pageViewController:self contentOffsetY:offsetY progress:progress];
@@ -986,7 +986,7 @@
     NSString *key = [self getKeyWithTitle:title];
     UIScrollView *scrollView = nil;
     
-    if (![self.scrollViewCacheDictionryM objectForKey:key]) {
+    if (![self.scrollViewCacheDictionaryM objectForKey:key]) {
         if (self.dataSource && [self.dataSource respondsToSelector:@selector(pageViewController:pageForIndex:)]) {
             scrollView = [self.dataSource pageViewController:self pageForIndex:pageIndex];
             scrollView.yn_observerDidScrollView = YES;
@@ -995,8 +995,8 @@
                 [weakSelf yn_pageScrollViewDidScrollView:scrollView];
             };
             if (self.config.pageStyle == YNPageStyleSuspensionTopPause) {
-                scrollView.yn_pageScrollViewBeginDragginScrollView = ^(UIScrollView *scrollView) {
-                    [weakSelf yn_pageScrollViewBeginDragginScrollView:scrollView];
+                scrollView.yn_pageScrollViewBeginDraggingScrollView = ^(UIScrollView *scrollView) {
+                    [weakSelf yn_pageScrollViewBeginDraggingScrollView:scrollView];
                 };
             }
             if (@available(iOS 11.0, *)) {
@@ -1006,12 +1006,12 @@
             }
         }
     } else {
-        return [self.scrollViewCacheDictionryM objectForKey:key];
+        return [self.scrollViewCacheDictionaryM objectForKey:key];
     }
 #if DEBUG
     NSAssert(scrollView != nil, @"请设置pageViewController 的数据源！");
 #endif
-    [self.scrollViewCacheDictionryM setObject:scrollView forKey:key];
+    [self.scrollViewCacheDictionaryM setObject:scrollView forKey:key];
     return scrollView;
 }
 

--- a/YNPageViewController/YNPageViewController/Src/Demos/LoadPageVC/YNLoadPageVC.m
+++ b/YNPageViewController/YNPageViewController/Src/Demos/LoadPageVC/YNLoadPageVC.m
@@ -48,29 +48,29 @@
     /// 模拟器请求
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         [self setupPageVC];
-        [_indicatorView stopAnimating];
-        [_indicatorView setHidden:YES];
+        [self->_indicatorView stopAnimating];
+        [self->_indicatorView setHidden:YES];
     });
     [self.view addSubview:_indicatorView];
 }
 
 - (void)setupPageVC {
-    YNPageConfigration *configration = [YNPageConfigration defaultConfig];
-    configration.pageStyle = YNPageStyleSuspensionCenter;
-    configration.headerViewCouldScale = YES;
-    //    configration.headerViewScaleMode = YNPageHeaderViewScaleModeCenter;
-    configration.headerViewScaleMode = YNPageHeaderViewScaleModeTop;
+    YNPageConfiguration *configuration = [YNPageConfiguration defaultConfig];
+    configuration.pageStyle = YNPageStyleSuspensionCenter;
+    configuration.headerViewCouldScale = YES;
+    //    configuration.headerViewScaleMode = YNPageHeaderViewScaleModeCenter;
+    configuration.headerViewScaleMode = YNPageHeaderViewScaleModeTop;
     /// 控制tabbar 和 nav
-    configration.showTabbar = NO;
-    configration.showNavigation = NO;
-    configration.scrollMenu = NO;
-    configration.aligmentModeCenter = NO;
-    configration.lineWidthEqualFontWidth = NO;
-    configration.showBottomLine = YES;
-    configration.suspenOffsetY = 64;
+    configuration.showTabBar = NO;
+    configuration.showNavigation = NO;
+    configuration.scrollMenu = NO;
+    configuration.alignmentModeCenter = NO;
+    configuration.lineWidthEqualFontWidth = NO;
+    configuration.showBottomLine = YES;
+    configuration.suspendOffsetY = 64;
     /// 裁剪高度
-    configration.cutOutHeight = 44;
-    YNSuspendCenterPageVC *pageVC = [YNSuspendCenterPageVC suspendCenterPageVCWithConfig:configration];
+    configuration.cutOutHeight = 44;
+    YNSuspendCenterPageVC *pageVC = [YNSuspendCenterPageVC suspendCenterPageVCWithConfig:configuration];
     
     /// 作为自控制器加入到当前控制器
     [pageVC addSelfToParentViewController:self];

--- a/YNPageViewController/YNPageViewController/Src/Demos/NavPageVC/YNNavPageVC.m
+++ b/YNPageViewController/YNPageViewController/Src/Demos/NavPageVC/YNNavPageVC.m
@@ -20,14 +20,14 @@
 }
 
 + (instancetype)navPageVC {
-    YNPageConfigration *configration = [YNPageConfigration defaultConfig];
+    YNPageConfiguration *configration = [YNPageConfiguration defaultConfig];
     configration.pageStyle = YNPageStyleNavigation;
     configration.headerViewCouldScale = YES;
     configration.headerViewScaleMode = YNPageHeaderViewScaleModeTop;
-    configration.showTabbar = NO;
+    configration.showTabBar = NO;
     configration.showNavigation = YES;
     configration.scrollMenu = NO;
-    configration.aligmentModeCenter = NO;
+    configration.alignmentModeCenter = NO;
     configration.lineWidthEqualFontWidth = NO;
     configration.showBottomLine = YES;
     /// 设置菜单栏宽度

--- a/YNPageViewController/YNPageViewController/Src/Demos/ScrollMenuStyleVC/YNScrollMenuStyleVC.m
+++ b/YNPageViewController/YNPageViewController/Src/Demos/ScrollMenuStyleVC/YNScrollMenuStyleVC.m
@@ -8,7 +8,7 @@
 
 #import "YNScrollMenuStyleVC.h"
 #import "YNPageScrollMenuView.h"
-#import "YNPageConfigration.h"
+#import "YNPageConfiguration.h"
 #import "UIView+YNPageExtend.h"
 
 @interface YNScrollMenuStyleVC ()
@@ -26,64 +26,64 @@
     _scrollView.backgroundColor = [UIColor groupTableViewBackgroundColor];
     
     /// style 1
-    YNPageConfigration *firstConfigStyle = [YNPageConfigration defaultConfig];
-    YNPageScrollMenuView *firstStyle = [YNPageScrollMenuView pagescrollMenuViewWithFrame:CGRectMake(0, 0, kSCREEN_WIDTH, 44) titles:@[@"JAVA", @"Object-C", @"JS"].mutableCopy configration:firstConfigStyle delegate:nil currentIndex:0];
+    YNPageConfiguration *firstConfigStyle = [YNPageConfiguration defaultConfig];
+    YNPageScrollMenuView *firstStyle = [YNPageScrollMenuView pageScrollMenuViewWithFrame:CGRectMake(0, 0, kSCREEN_WIDTH, 44) titles:@[@"JAVA", @"Object-C", @"JS"].mutableCopy configuration:firstConfigStyle delegate:nil currentIndex:0];
     
     /// style 2
-    YNPageConfigration *secondConfigStyle = [YNPageConfigration defaultConfig];
+    YNPageConfiguration *secondConfigStyle = [YNPageConfiguration defaultConfig];
     secondConfigStyle.showBottomLine = YES;
     secondConfigStyle.bottomLineBgColor = [UIColor greenColor];
     secondConfigStyle.bottomLineHeight = 1;
     
-    YNPageScrollMenuView *secondStyle = [YNPageScrollMenuView pagescrollMenuViewWithFrame:CGRectMake(0, firstStyle.yn_bottom + 20, kSCREEN_WIDTH, 44) titles:@[@"系统偏好设置", @"网易云音乐", @"有道词典", @"微信", @"QQ游戏", @"QQ邮箱", @"数码测色计"].mutableCopy configration:secondConfigStyle delegate:nil currentIndex:0];
+    YNPageScrollMenuView *secondStyle = [YNPageScrollMenuView pageScrollMenuViewWithFrame:CGRectMake(0, firstStyle.yn_bottom + 20, kSCREEN_WIDTH, 44) titles:@[@"系统偏好设置", @"网易云音乐", @"有道词典", @"微信", @"QQ游戏", @"QQ邮箱", @"数码测色计"].mutableCopy configuration:secondConfigStyle delegate:nil currentIndex:0];
     
     /// style 3
-    YNPageConfigration *thirdConfigStyle = [YNPageConfigration defaultConfig];
+    YNPageConfiguration *thirdConfigStyle = [YNPageConfiguration defaultConfig];
     thirdConfigStyle.showBottomLine = YES;
     thirdConfigStyle.bottomLineBgColor = [UIColor greenColor];
     thirdConfigStyle.bottomLineHeight = 1;
     thirdConfigStyle.scrollMenu = NO;
-    thirdConfigStyle.aligmentModeCenter = NO;
+    thirdConfigStyle.alignmentModeCenter = NO;
     thirdConfigStyle.lineWidthEqualFontWidth = NO;
     thirdConfigStyle.showBottomLine = YES;
     thirdConfigStyle.itemFont = [UIFont systemFontOfSize:14];
     thirdConfigStyle.selectedItemColor = [UIColor redColor];
     thirdConfigStyle.normalItemColor = [UIColor blackColor];
     
-    YNPageScrollMenuView *thirdStyle = [YNPageScrollMenuView pagescrollMenuViewWithFrame:CGRectMake(0, secondStyle.yn_bottom + 20, kSCREEN_WIDTH, 44) titles:@[@"QQ游戏", @"QQ邮箱", @"数码测色计"].mutableCopy configration:thirdConfigStyle delegate:nil currentIndex:0];
+    YNPageScrollMenuView *thirdStyle = [YNPageScrollMenuView pageScrollMenuViewWithFrame:CGRectMake(0, secondStyle.yn_bottom + 20, kSCREEN_WIDTH, 44) titles:@[@"QQ游戏", @"QQ邮箱", @"数码测色计"].mutableCopy configuration:thirdConfigStyle delegate:nil currentIndex:0];
     
     /// style 4
-    YNPageConfigration *fourthConfigStyle = [YNPageConfigration defaultConfig];
-    fourthConfigStyle.converColor = [UIColor grayColor];
-    fourthConfigStyle.showConver = YES;
+    YNPageConfiguration *fourthConfigStyle = [YNPageConfiguration defaultConfig];
+    fourthConfigStyle.coverColor = [UIColor grayColor];
+    fourthConfigStyle.showCover = YES;
     fourthConfigStyle.itemFont = [UIFont systemFontOfSize:20];
     fourthConfigStyle.selectedItemFont = [UIFont systemFontOfSize:20];
     fourthConfigStyle.selectedItemColor = [UIColor redColor];
     fourthConfigStyle.normalItemColor = [UIColor blackColor];
     fourthConfigStyle.itemMaxScale = 1.3;
     
-    YNPageScrollMenuView *fourthStyle = [YNPageScrollMenuView pagescrollMenuViewWithFrame:CGRectMake(0, thirdStyle.yn_bottom + 20, kSCREEN_WIDTH, 44) titles:@[@"QQ游戏", @"QQ邮箱", @"数码测色计"].mutableCopy configration:fourthConfigStyle delegate:nil currentIndex:2];
+    YNPageScrollMenuView *fourthStyle = [YNPageScrollMenuView pageScrollMenuViewWithFrame:CGRectMake(0, thirdStyle.yn_bottom + 20, kSCREEN_WIDTH, 44) titles:@[@"QQ游戏", @"QQ邮箱", @"数码测色计"].mutableCopy configuration:fourthConfigStyle delegate:nil currentIndex:2];
     
     /// style 5
-    YNPageConfigration *fifthConfigStyle = [YNPageConfigration defaultConfig];
+    YNPageConfiguration *fifthConfigStyle = [YNPageConfiguration defaultConfig];
     fifthConfigStyle.selectedItemColor = [UIColor redColor];
     fifthConfigStyle.selectedItemFont = [UIFont systemFontOfSize:15];
     
-    YNPageScrollMenuView *fifthStyle = [YNPageScrollMenuView pagescrollMenuViewWithFrame:CGRectMake(0, fourthStyle.yn_bottom + 20, kSCREEN_WIDTH, 44) titles:@[@"JAVA", @"Object-C", @"JS"].mutableCopy configration:fifthConfigStyle delegate:nil currentIndex:1];
+    YNPageScrollMenuView *fifthStyle = [YNPageScrollMenuView pageScrollMenuViewWithFrame:CGRectMake(0, fourthStyle.yn_bottom + 20, kSCREEN_WIDTH, 44) titles:@[@"JAVA", @"Object-C", @"JS"].mutableCopy configuration:fifthConfigStyle delegate:nil currentIndex:1];
     
     /// style 6
-    YNPageConfigration *sixthConfigStyle = [YNPageConfigration defaultConfig];
+    YNPageConfiguration *sixthConfigStyle = [YNPageConfiguration defaultConfig];
     sixthConfigStyle.scrollMenu = YES;
-    sixthConfigStyle.aligmentModeCenter = NO;
+    sixthConfigStyle.alignmentModeCenter = NO;
     sixthConfigStyle.bottomLineHeight = 1;
     sixthConfigStyle.bottomLineBgColor = [UIColor greenColor];
     sixthConfigStyle.showBottomLine = YES;
-    YNPageScrollMenuView *sixthStyle = [YNPageScrollMenuView pagescrollMenuViewWithFrame:CGRectMake(0, fifthStyle.yn_bottom + 20, kSCREEN_WIDTH, 44) titles:@[@"JAVA", @"Object-C", @"JS"].mutableCopy configration:sixthConfigStyle delegate:nil currentIndex:1];
+    YNPageScrollMenuView *sixthStyle = [YNPageScrollMenuView pageScrollMenuViewWithFrame:CGRectMake(0, fifthStyle.yn_bottom + 20, kSCREEN_WIDTH, 44) titles:@[@"JAVA", @"Object-C", @"JS"].mutableCopy configuration:sixthConfigStyle delegate:nil currentIndex:1];
     
     /// style 7
-    YNPageConfigration *seventhConfigStyle = [YNPageConfigration defaultConfig];
+    YNPageConfiguration *seventhConfigStyle = [YNPageConfiguration defaultConfig];
     seventhConfigStyle.scrollMenu = NO;
-    seventhConfigStyle.aligmentModeCenter = NO;
+    seventhConfigStyle.alignmentModeCenter = NO;
     NSMutableArray *buttonArrayM = @[].mutableCopy;
     for (int i = 0; i < 3; i++) {
         UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
@@ -96,7 +96,7 @@
     }
     seventhConfigStyle.buttonArray = buttonArrayM;
     
-    YNPageScrollMenuView *seventhStyle = [YNPageScrollMenuView pagescrollMenuViewWithFrame:CGRectMake(0, sixthStyle.yn_bottom + 20, kSCREEN_WIDTH, 44) titles:@[@"带iCON", @"小图标", @"位置"].mutableCopy configration:seventhConfigStyle delegate:nil currentIndex:1];
+    YNPageScrollMenuView *seventhStyle = [YNPageScrollMenuView pageScrollMenuViewWithFrame:CGRectMake(0, sixthStyle.yn_bottom + 20, kSCREEN_WIDTH, 44) titles:@[@"带iCON", @"小图标", @"位置"].mutableCopy configuration:seventhConfigStyle delegate:nil currentIndex:1];
     
     [_scrollView addSubview:firstStyle];
     [_scrollView addSubview:secondStyle];

--- a/YNPageViewController/YNPageViewController/Src/Demos/SuspendCenterPageVC/YNSuspendCenterPageVC.h
+++ b/YNPageViewController/YNPageViewController/Src/Demos/SuspendCenterPageVC/YNSuspendCenterPageVC.h
@@ -7,12 +7,12 @@
 //
 
 #import "BasePageViewController.h"
-#import "YNPageConfigration.h"
+#import "YNPageConfiguration.h"
 
 @interface YNSuspendCenterPageVC : BasePageViewController
 
 + (instancetype)suspendCenterPageVC;
 
-+ (instancetype)suspendCenterPageVCWithConfig:(YNPageConfigration *)config;
++ (instancetype)suspendCenterPageVCWithConfig:(YNPageConfiguration *)config;
 
 @end

--- a/YNPageViewController/YNPageViewController/Src/Demos/SuspendCenterPageVC/YNSuspendCenterPageVC.m
+++ b/YNPageViewController/YNPageViewController/Src/Demos/SuspendCenterPageVC/YNSuspendCenterPageVC.m
@@ -27,21 +27,21 @@
 
 #pragma mark - Public Function
 + (instancetype)suspendCenterPageVC {
-    YNPageConfigration *configration = [YNPageConfigration defaultConfig];
+    YNPageConfiguration *configration = [YNPageConfiguration defaultConfig];
     configration.pageStyle = YNPageStyleSuspensionCenter;
     configration.headerViewCouldScale = YES;
     //    configration.headerViewScaleMode = YNPageHeaderViewScaleModeCenter;
     configration.headerViewScaleMode = YNPageHeaderViewScaleModeTop;
-    configration.showTabbar = NO;
+    configration.showTabBar = NO;
     configration.showNavigation = YES;
     configration.scrollMenu = NO;
-    configration.aligmentModeCenter = NO;
+    configration.alignmentModeCenter = NO;
     configration.lineWidthEqualFontWidth = true;
     configration.showBottomLine = YES;
     return [self suspendCenterPageVCWithConfig:configration];
 }
 
-+ (instancetype)suspendCenterPageVCWithConfig:(YNPageConfigration *)config {
++ (instancetype)suspendCenterPageVCWithConfig:(YNPageConfiguration *)config {
     YNSuspendCenterPageVC *vc = [YNSuspendCenterPageVC pageViewControllerWithControllers:[self getArrayVCs]
                                                                                   titles:[self getArrayTitles]
                                                                                   config:config];

--- a/YNPageViewController/YNPageViewController/Src/Demos/SuspendCustomNavOrSuspendPositionVC/YNSuspendCustomNavOrSuspendPositionVC.m
+++ b/YNPageViewController/YNPageViewController/Src/Demos/SuspendCustomNavOrSuspendPositionVC/YNSuspendCustomNavOrSuspendPositionVC.m
@@ -44,30 +44,30 @@
     /// 模拟器请求
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         [self setupPageVC];
-        [_indicatorView stopAnimating];
-        [_indicatorView setHidden:YES];
+        [self->_indicatorView stopAnimating];
+        [self->_indicatorView setHidden:YES];
     });
     [self.view addSubview:_indicatorView];
 }
 
 - (void)setupPageVC {
     
-    YNPageConfigration *configration = [YNPageConfigration defaultConfig];
-    configration.pageStyle = YNPageStyleSuspensionCenter;
-    configration.headerViewCouldScale = YES;
+    YNPageConfiguration *configuration = [YNPageConfiguration defaultConfig];
+    configuration.pageStyle = YNPageStyleSuspensionCenter;
+    configuration.headerViewCouldScale = YES;
     /// 控制tabbar 和 nav
-    configration.showTabbar = NO;
-    configration.showNavigation = NO;
-    configration.scrollMenu = NO;
-    configration.aligmentModeCenter = NO;
-    configration.lineWidthEqualFontWidth = NO;
-    configration.showBottomLine = YES;
+    configuration.showTabBar = NO;
+    configuration.showNavigation = NO;
+    configuration.scrollMenu = NO;
+    configuration.alignmentModeCenter = NO;
+    configuration.lineWidthEqualFontWidth = NO;
+    configuration.showBottomLine = YES;
     /// 设置悬浮停顿偏移量
-    configration.suspenOffsetY = kYNPAGE_NAVHEIGHT;
+    configuration.suspendOffsetY = kYNPAGE_NAVHEIGHT;
     
     YNPageViewController *vc = [YNPageViewController pageViewControllerWithControllers:self.getArrayVCs
                                                                                 titles:[self getArrayTitles]
-                                                                                config:configration];
+                                                                                config:configuration];
     vc.dataSource = self;
     vc.delegate = self;
     

--- a/YNPageViewController/YNPageViewController/Src/Demos/SuspendTopPageVC/YNSuspendTopPageVC.m
+++ b/YNPageViewController/YNPageViewController/Src/Demos/SuspendTopPageVC/YNSuspendTopPageVC.m
@@ -26,13 +26,13 @@
 #pragma mark - Public Function
 
 + (instancetype)suspendTopPageVC {
-    YNPageConfigration *configration = [YNPageConfigration defaultConfig];
+    YNPageConfiguration *configration = [YNPageConfiguration defaultConfig];
     configration.pageStyle = YNPageStyleSuspensionTop;
     configration.headerViewCouldScale = YES;
-    configration.showTabbar = NO;
+    configration.showTabBar = NO;
     configration.showNavigation = YES;
     configration.scrollMenu = NO;
-    configration.aligmentModeCenter = NO;
+    configration.alignmentModeCenter = NO;
     configration.lineWidthEqualFontWidth = NO;
     configration.showBottomLine = YES;
     

--- a/YNPageViewController/YNPageViewController/Src/Demos/SuspendTopPausePageVC/YNSuspendTopPauseBaseTableViewVC.m
+++ b/YNPageViewController/YNPageViewController/Src/Demos/SuspendTopPausePageVC/YNSuspendTopPauseBaseTableViewVC.m
@@ -31,7 +31,7 @@
     /// 加载数据
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         for (int i = 0; i < 420; i++) {
-            [_dataArray addObject:@""];
+            [self->_dataArray addObject:@""];
         }
         [self.tableView reloadData];
     });

--- a/YNPageViewController/YNPageViewController/Src/Demos/SuspendTopPausePageVC/YNSuspendTopPausePageVC.m
+++ b/YNPageViewController/YNPageViewController/Src/Demos/SuspendTopPausePageVC/YNSuspendTopPausePageVC.m
@@ -40,13 +40,13 @@
 #pragma mark - Public Function
 
 + (instancetype)suspendTopPausePageVC {
-    YNPageConfigration *configration = [YNPageConfigration defaultConfig];
+    YNPageConfiguration *configration = [YNPageConfiguration defaultConfig];
     configration.pageStyle = YNPageStyleSuspensionTopPause;
     configration.headerViewCouldScale = YES;
-    configration.showTabbar = NO;
+    configration.showTabBar = NO;
     configration.showNavigation = YES;
     configration.scrollMenu = NO;
-    configration.aligmentModeCenter = NO;
+    configration.alignmentModeCenter = NO;
     configration.lineWidthEqualFontWidth = NO;
     configration.showBottomLine = YES;
     

--- a/YNPageViewController/YNPageViewController/Src/Demos/TestPageVC/YNTestPageVC.m
+++ b/YNPageViewController/YNPageViewController/Src/Demos/TestPageVC/YNTestPageVC.m
@@ -44,17 +44,17 @@
 
 #pragma mark - Public Function
 + (instancetype)testPageVC {
-    YNPageConfigration *configration = [YNPageConfigration defaultConfig];
+    YNPageConfiguration *configration = [YNPageConfiguration defaultConfig];
     configration.pageStyle = YNPageStyleSuspensionTopPause;
     //    configration.pageStyle = YNPageStyleNavigation;
     //    configration.pageStyle = YNPageStyleTop;
     configration.headerViewCouldScale = YES;
     //    configration.headerViewScaleMode = YNPageHeaderViewScaleModeCenter;
     configration.headerViewScaleMode = YNPageHeaderViewScaleModeTop;
-    configration.showTabbar = NO;
+    configration.showTabBar = NO;
     configration.showNavigation = YES;
     configration.scrollMenu = NO;
-    configration.aligmentModeCenter = NO;
+    configration.alignmentModeCenter = NO;
     configration.lineWidthEqualFontWidth = NO;
     //    configration.menuWidth = 250;
     

--- a/YNPageViewController/YNPageViewController/Src/Demos/TopPageVC/YNTopPageVC.m
+++ b/YNPageViewController/YNPageViewController/Src/Demos/TopPageVC/YNTopPageVC.m
@@ -20,14 +20,14 @@
 }
 
 + (instancetype)topPageVC {
-    YNPageConfigration *configration = [YNPageConfigration defaultConfig];
+    YNPageConfiguration *configration = [YNPageConfiguration defaultConfig];
         configration.pageStyle = YNPageStyleTop;
     configration.headerViewCouldScale = YES;
     configration.headerViewScaleMode = YNPageHeaderViewScaleModeTop;
-    configration.showTabbar = NO;
+    configration.showTabBar = NO;
     configration.showNavigation = YES;
     configration.scrollMenu = NO;
-    configration.aligmentModeCenter = NO;
+    configration.alignmentModeCenter = NO;
     configration.lineWidthEqualFontWidth = NO;
     configration.showBottomLine = YES;
     


### PR DESCRIPTION
I have fixed massive warnings and typos in code, might have some API name changes like `wordowrdWord` to `wordWordWord`. I think Xcode can handle these kind of minor changes very well.